### PR TITLE
debug copymetadata missing in itkFiltersThresholdingProcess

### DIFF
--- a/src-plugins/itkFilters/itkFiltersThresholdingProcess_p.h
+++ b/src-plugins/itkFilters/itkFiltersThresholdingProcess_p.h
@@ -65,7 +65,8 @@ public:
             std::cerr << err << std::endl;
         }
 
-        
+        output->copyMetaDataFrom(input);
+
         QString newSeriesDescription = input->metadata ( medMetaDataKeys::SeriesDescription.key() );
         newSeriesDescription += " threshold (" + QString::number(threshold) + ")";
     


### PR DESCRIPTION
:cactus: 
Plop

"output->copyMetaDataFrom(input);" was missing in itkFiltersThresholdingProcess in order to save metadata from input to output.

Mathilde M.
:hamster: 