### PR TITLE
medFilteringWorkspace debug for binaryOperations + debug() messages expl...

### DIFF
--- a/app/medInria/medFilteringWorkspace.cpp
+++ b/app/medInria/medFilteringWorkspace.cpp
@@ -128,8 +128,6 @@ void medFilteringWorkspace::onProcessSuccess()
     if ( !d->filterOutput )
         return;
 
-    qDebug() << "d->filterOutput->identifier()" << d->filterOutput->identifier();
-
     medAbstractData *inputData(d->filteringToolBox->data());
 
     if (! d->filterOutput->hasMetaData(medMetaDataKeys::SeriesDescription.key()))
@@ -139,12 +137,15 @@ void medFilteringWorkspace::onProcessSuccess()
         d->filterOutput->addMetaData ( medMetaDataKeys::SeriesDescription.key(), newSeriesDescription );
       }
 
-    foreach ( QString metaData, inputData->metaDataList() )
-      if (!d->filterOutput->hasMetaData(metaData))
-        d->filterOutput->addMetaData ( metaData, inputData->metaDataValues ( metaData ) );
+    if (inputData) // ex: binaryOperation without any data in "Input" container
+    {
+        foreach ( QString metaData, inputData->metaDataList() )
+            if (!d->filterOutput->hasMetaData(metaData))
+                d->filterOutput->addMetaData ( metaData, inputData->metaDataValues ( metaData ) );
 
-    foreach ( QString property, inputData->propertyList() )
-      d->filterOutput->addProperty ( property,inputData->propertyValues ( property ) );
+        foreach ( QString property, inputData->propertyList() )
+            d->filterOutput->addProperty ( property,inputData->propertyValues ( property ) );
+    }
 
     QString generatedID = QUuid::createUuid().toString().replace("{","").replace("}","");
     d->filterOutput->setMetaData ( medMetaDataKeys::SeriesID.key(), generatedID );

--- a/src-plugins/itkFilters/itkFiltersAddProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersAddProcess.cpp
@@ -75,7 +75,7 @@ int itkFiltersAddProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersAddProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersCloseProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersCloseProcess.cpp
@@ -76,7 +76,7 @@ int itkFiltersCloseProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersCloseProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
@@ -76,7 +76,7 @@ int itkFiltersComponentSizeThresholdProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersComponentSizeThresholdProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {
@@ -112,7 +112,7 @@ int itkFiltersComponentSizeThresholdProcess::update ( void )
     }
     else
     {
-        qDebug() << "Error : pixel type not yet implemented ("
+        qDebug() << "itkFiltersComponentSizeThresholdProcess Error : pixel type not yet implemented ("
         << id
         << ")";
         return -1;

--- a/src-plugins/itkFilters/itkFiltersDilateProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersDilateProcess.cpp
@@ -92,7 +92,7 @@ int itkFiltersDilateProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersDilateProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersDivideProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersDivideProcess.cpp
@@ -74,7 +74,7 @@ int itkFiltersDivideProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersDivideProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersErodeProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersErodeProcess.cpp
@@ -74,7 +74,7 @@ int itkFiltersErodeProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersErodeProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersGaussianProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersGaussianProcess.cpp
@@ -76,7 +76,7 @@ int itkFiltersGaussianProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersGaussianProcess, update : " << id;
 
     try
     {

--- a/src-plugins/itkFilters/itkFiltersInvertProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersInvertProcess.cpp
@@ -61,7 +61,7 @@ int itkFiltersInvertProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersInvertProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
@@ -63,7 +63,7 @@ int itkFiltersMedianProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersMedianProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersMultiplyProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersMultiplyProcess.cpp
@@ -74,7 +74,7 @@ int itkFiltersMultiplyProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersMultiplyProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersNormalizeProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersNormalizeProcess.cpp
@@ -63,7 +63,7 @@ int itkFiltersNormalizeProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersNormalizeProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersOpenProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersOpenProcess.cpp
@@ -76,7 +76,7 @@ int itkFiltersOpenProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersOpenProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersShrinkProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersShrinkProcess.cpp
@@ -129,7 +129,7 @@ int itkFiltersShrinkProcess::update ( void )
     }
     else
     {
-        qDebug() << "Error : pixel type not yet implemented ("
+        qDebug() << "itkFiltersShrinkProcess Error : pixel type not yet implemented ("
         << id
         << ")";
         return -1;

--- a/src-plugins/itkFilters/itkFiltersSubtractProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersSubtractProcess.cpp
@@ -76,7 +76,7 @@ int itkFiltersSubtractProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersSubtractProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {

--- a/src-plugins/itkFilters/itkFiltersThresholdingProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersThresholdingProcess.cpp
@@ -83,8 +83,7 @@ int itkFiltersThresholdingProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
-
+    qDebug() << "itkFiltersThresholdingProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {
@@ -128,7 +127,7 @@ int itkFiltersThresholdingProcess::update ( void )
     }
     else
     {
-        qDebug() << "Error : pixel type not yet implemented ("
+        qDebug() << "itkFiltersThresholdingProcess Error : pixel type not yet implemented ("
         << id
         << ")";
         return -1;

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -396,6 +396,7 @@ void itkFiltersToolBox::update (medAbstractData *data )
     else
     {
         QString identifier = data->identifier();
+        qDebug() << "itkFiltersToolBox, update : " << identifier;
 
         if ( identifier == "itkDataImageChar3" )
         {
@@ -622,7 +623,7 @@ void itkFiltersToolBox::update (medAbstractData *data )
         }
         else
         {
-            qWarning() << "Error : pixel type not yet implemented ("
+            qWarning() << "itkFiltersToolBox Error : pixel type not yet implemented ("
             << identifier
             << ")";
         }

--- a/src-plugins/itkFilters/itkFiltersWindowingProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersWindowingProcess.cpp
@@ -90,7 +90,7 @@ int itkFiltersWindowingProcess::update ( void )
 
     QString id = d->input->identifier();
 
-    qDebug() << "itkFilters, update : " << id;
+    qDebug() << "itkFiltersWindowingProcess, update : " << id;
 
     if ( id == "itkDataImageChar3" )
     {
@@ -134,7 +134,7 @@ int itkFiltersWindowingProcess::update ( void )
     }
     else
     {
-        qDebug() << "Error : pixel type not yet implemented ("
+        qDebug() << "itkFiltersWindowingProcess Error : pixel type not yet implemented ("
         << id
         << ")";
         return -1;


### PR DESCRIPTION
medFilteringWorkspace : debug binaryOperation without any data in "Input" container. User do not need to add extra data in "Input" anymore.

qDebug() messages more explicit in itkFilters files.

:zap: :rabbit: 

Mathilde
