### PR TITLE
[PaintTBx] Breaks the link between the saved mask and the new one

### DIFF
--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -528,6 +528,8 @@ AlgorithmPaintToolbox::AlgorithmPaintToolbox(QWidget *parent ) :
     connect(removeSeed_shortcut,SIGNAL(activated()),this,SLOT(removeSeed()));
     connect(addBrushSize_shortcut,SIGNAL(activated()),this,SLOT(increaseBrushSize()));
     connect(reduceBrushSize_shortcut,SIGNAL(activated()),this,SLOT(reduceBrushSize()));
+
+    maskHasBeenSaved = false;
 }
 
 AlgorithmPaintToolbox::~AlgorithmPaintToolbox()
@@ -666,6 +668,7 @@ void AlgorithmPaintToolbox::import()
 {
     setOutputMetadata(m_imageData, m_maskData);
     medDataManager::instance()->importData(m_maskData, true);
+    maskHasBeenSaved = true;
 }
 
 void AlgorithmPaintToolbox::setWorkspace(medAbstractWorkspace* workspace)
@@ -745,6 +748,12 @@ void AlgorithmPaintToolbox::clearMask()
         m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
 
         m_maskAnnotationData->invokeModified();
+
+        if(maskHasBeenSaved)
+        {
+            m_imageData->removeAttachedData(m_maskAnnotationData);
+            maskHasBeenSaved = false;
+        }
     }
 }
 

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
@@ -179,6 +179,7 @@ private:
     QLabel *m_brushRadiusLabel;
     QShortcut *addBrushSize_shortcut, *reduceBrushSize_shortcut;
     double m_strokeRadius;
+    bool maskHasBeenSaved;
     //
 
     // Magic Wand's objects


### PR DESCRIPTION
Original purpose : be able to make independent paint segmentationS on the same volume.
The problem was : you segment something, you save it, rename it ("mask1" for instance). Then clear.
Draw something else, save it, rename it ("mask2").
Now display mask2; it's fine.
Display mask1 : mask1 = mask2 !

It comes from the fact that after clearing, mask1 is set to an empty mask (fully black) and is still "attached" to the volume. So when drawing mask2, you're actually overwriting mask1.
So now every time you press Clear (after having saved), it removes the current attached data, thus later a new attachedData is created.
