### PR TITLE
[PaintTbx] Improving usability, getting rid of multi-layer  management and removing useless code

### DIFF
--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -1818,11 +1818,6 @@ void AlgorithmPaintToolbox::increaseBrushSize()
     addBrushSize(1);
     if (!currentView)
         return;
-    //if (cursorOn && !cursorJustReactivated) 
-    //{
-        //removeCursorDisplay();
-        //updateStroke(m_viewFilter,currentView);
-    //}
 }
 
 void AlgorithmPaintToolbox::reduceBrushSize()
@@ -1830,10 +1825,6 @@ void AlgorithmPaintToolbox::reduceBrushSize()
     addBrushSize(-1);
     if (!currentView)
         return;
-}
-
-void AlgorithmPaintToolbox::setCursorOn(bool value)
-{
 }
 
 void AlgorithmPaintToolbox::interpolate()

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -64,15 +64,11 @@ public:
         m_cb(cb),
         m_paintState(PaintState::None),
         m_lastPaintState(PaintState::None),
-		timer()/*,cursorJustReactivated(true)*/{}
+		timer(){}
    
 
     virtual bool mousePressEvent(medAbstractView *view, QMouseEvent *mouseEvent )
     {
-        bool shouldWeRetrieveData = true;
-        if(m_paintState == m_cb->paintState())
-            shouldWeRetrieveData = false;
-
         m_paintState = m_cb->paintState();
 
         if ( this->m_paintState == PaintState::DeleteStroke )
@@ -160,10 +156,8 @@ public:
 
         if (m_paintState == PaintState::None 
             && (m_cb->m_paintState == PaintState::Stroke || m_cb->m_paintState == PaintState::DeleteStroke) 
-            && (/*m_cb->getCursorOn() ||*/ m_cb->undoRedoCopyPasteModeOn))
+            && (m_cb->undoRedoCopyPasteModeOn))
         {
-            //m_cb->undoRedoCopyPasteModeOn = false;
-            //m_cb->setCursorOn(true);
             mouseEvent->accept();
 
             int elapsed = timer.elapsed();
@@ -171,11 +165,6 @@ public:
             qDebug() << elapsed;
             if (elapsed<10) // 1000/24 (24 images per second)
                 return false;
-
-            //if (!m_cb->cursorJustReactivated )
-            //    m_cb->removeCursorDisplay();  
-            //else
-            //    m_cb->cursorJustReactivated  = false;
 
             if (imageView->is2D())
             {
@@ -203,7 +192,6 @@ public:
         if ( this->m_paintState == PaintState::None )
             return false;
 
-        //m_cb->setCursorOn(false); 
         mouseEvent->accept();
 
         if (imageView->is2D())
@@ -229,8 +217,6 @@ public:
         {
             m_paintState = PaintState::None; //Painting is done
             m_cb->updateStroke(this, imageView);
-            //m_cb->setCursorOn(true);
-            //m_cb->cursorJustReactivated  = true;
             this->m_points.clear();
             timer.start();
             return true;
@@ -252,44 +238,9 @@ public:
                 m_cb->addBrushSize(-numSteps);
             else 
                 m_cb->addBrushSize(numSteps);
-            
-            //if (!m_cb->cursorJustReactivated && m_paintState!=PaintState::Stroke )
-            //{
-            //    //m_cb->removeCursorDisplay();
-            //    m_cb->updateStroke(this,imageView);
-            //}
             return true;   
         }
         return false;
-    }
-
-    virtual bool leaveEvent(medAbstractView *view, QEvent * event)
-    {
-        /*if (m_cb->getCursorOn())
-            view->setProperty("Cursor","Normal");
-        else
-            return false;*/
-        //if (!m_cb->getCursorOn())
-        //    return false;
-        
-        //m_cb->removeCursorDisplay();
-        //m_cb->cursorJustReactivated  = true;
-
-        return true;
-    }
-
-    virtual bool enterEvent(medAbstractView *view, QEvent *event)
-    {
-        /*if (m_cb->getCursorOn())
-            if (m_paintState != PaintState::DeleteStroke)
-                view->setProperty("Cursor","None");*/
-
-        //m_cb->setCurrentView(view);
-
-        /*dtkAbstractData * viewData = medSegmentationSelectorToolBox::viewData( view );
-        m_cb->setData( viewData );
-        return true;*/
-        return true;
     }
 	
     const std::vector<QVector3D> & points() const { return m_points; }
@@ -300,7 +251,6 @@ private :
     PaintState::E m_paintState;
     PaintState::E m_lastPaintState;
 	QTime timer; // timer used to improve the visualization of the cursor
-    //bool cursorJustReactivated; // helps with the cursor
 };
 
 AlgorithmPaintToolbox::AlgorithmPaintToolbox(QWidget *parent ) :
@@ -518,12 +468,9 @@ AlgorithmPaintToolbox::AlgorithmPaintToolbox(QWidget *parent ) :
     m_undoStacks = new QHash<medAbstractView*,QStack<PairListSlicePlaneId>*>();
     m_redoStacks = new QHash<medAbstractView*,QStack<PairListSlicePlaneId>*>();
 
-    //cursorOn = false;
-    //cursorPixels = new QList<QPair<MaskType::IndexType,unsigned char> >();
     currentPlaneIndex = 0;
     currentIdSlice = 0;
     undoRedoCopyPasteModeOn = false;
-    //cursorJustReactivated = true;
     currentView = 0;
 
     //Shortcuts
@@ -632,7 +579,6 @@ void AlgorithmPaintToolbox::activateMagicWand()
         updateButtons();
         return;
     }
-    //setCursorOn(false);
     setPaintState(PaintState::Wand);
     updateButtons();
     this->m_strokeButton->setChecked(false);
@@ -1246,9 +1192,6 @@ void AlgorithmPaintToolbox::updateStroke(ClickAndMoveEventFilter * filter, medAb
         break;
     }
 
-    /* (cursorOn)
-        cursorPixels->clear();*/
-
     MaskType::IndexType index;
     itk::Point<ElemType,3> testPt;
 
@@ -1265,13 +1208,6 @@ void AlgorithmPaintToolbox::updateStroke(ClickAndMoveEventFilter * filter, medAb
 
             bool isInside = m_itkMask->TransformPhysicalPointToIndex( testPt, index );
             if ( isInside ) {
-                /*if (cursorOn) 
-                {
-                    if (pxValue == m_strokeLabel && m_itkMask->GetPixel(index)!=pxValue)
-                        cursorPixels->append(QPair<MaskType::IndexType,unsigned char>(index,m_itkMask->GetPixel(index)));
-                    if (pxValue == medSegmentationSelectorToolBox::MaskPixelValues::Unset && m_itkMask->GetPixel(index)!=medSegmentationSelectorToolBox::MaskPixelValues::Unset)
-                        cursorPixels->append(QPair<MaskType::IndexType,unsigned char>(index,m_itkMask->GetPixel(index)));
-                }*/
                 m_itkMask->SetPixel( index, pxValue );
             }
         }
@@ -1464,14 +1400,6 @@ void AlgorithmPaintToolbox::undo()
     region.SetSize(size);
     region.SetIndex(index2d);
 
-    //undoRedoCopyPasteModeOn = true;
-
-    //if (getCursorOn())
-    //{
-    //    removeCursorDisplay(); // before doing anything we need to remove the cursor if it is on
-    //    cursorOn = false;
-    //}
-    
     QList<SlicePair> list;
     for(int i = 0;i<previousState.first.length();i++)
     {
@@ -1491,8 +1419,6 @@ void AlgorithmPaintToolbox::undo()
     m_itkMask->GetPixelContainer()->Modified();
     m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
     m_maskAnnotationData->invokeModified();
-
-    //saveCurrentStateForCursor(currentView,currentPlaneIndex,currentIdSlice);
 }
 
 void AlgorithmPaintToolbox::redo()
@@ -1533,14 +1459,6 @@ void AlgorithmPaintToolbox::redo()
     region.SetSize(size);
     region.SetIndex(index2d);
 
-    //undoRedoCopyPasteModeOn = true;
-
-    //if (getCursorOn())
-    //{
-    //    /removeCursorDisplay(); // before doing anything we need to remove the cursor if it is on
-    //    cursorOn = false;
-    //}
-
     QList<SlicePair> list;
     for(int i = 0;i<nextState.first.length();i++)
     {
@@ -1559,8 +1477,6 @@ void AlgorithmPaintToolbox::redo()
     m_itkMask->GetPixelContainer()->Modified();
     m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
     m_maskAnnotationData->invokeModified();
-    
-    //saveCurrentStateForCursor(currentView,currentPlaneIndex,currentIdSlice);
 }
 
 void AlgorithmPaintToolbox::addSliceToStack(medAbstractView * view,const unsigned char planeIndex,QList<int> listIdSlice)
@@ -1615,46 +1531,6 @@ void AlgorithmPaintToolbox::addSliceToStack(medAbstractView * view,const unsigne
     if (m_redoStacks->contains(view))
             m_redoStacks->value(view)->clear();
 }
-
-/*void AlgorithmPaintToolbox::saveCurrentStateForCursor(medAbstractView * view,const unsigned char planeIndex,unsigned int idSlice)
-{
-   // save the current state for the cursor
-
-   if (!view)
-       return;
-
-   // copy code
-   MaskType::RegionType requestedRegion = m_itkMask->GetLargestPossibleRegion();
-   Mask2dType::IndexType index2d;
-   Mask2dType::RegionType region;
-   Mask2dType::RegionType::SizeType size;
-   
-   unsigned int i, j;
-   char direction[2];
-   for (i = 0, j = 0; i < 3; ++i )
-   {
-       if (i != planeIndex)
-       {
-           direction[j] = i;
-           j++;
-       }
-   }
-
-    index2d[ direction[0] ]    = requestedRegion.GetIndex()[ direction[0] ];
-    index2d[ 1- direction[0] ] = requestedRegion.GetIndex()[ direction[1] ];
-    size[ direction[0] ]     = requestedRegion.GetSize()[  direction[0] ];
-    size[ 1- direction[0] ]  = requestedRegion.GetSize()[  direction[1] ];
-
-    region.SetSize(size);
-    region.SetIndex(index2d);
-
-    //if (!currentStateForCursor)
-        currentStateForCursor = Mask2dType::New();
-    
-    currentStateForCursor->SetRegions(region);
-    currentStateForCursor->Allocate();
-    copySliceFromMask3D(currentStateForCursor,planeIndex,direction,idSlice);
-}*/
 
 
 void AlgorithmPaintToolbox::onViewClosed()
@@ -1794,14 +1670,6 @@ void AlgorithmPaintToolbox::copySliceMask()
     region.SetSize(size);
     region.SetIndex(index2d);
 
-    //undoRedoCopyPasteModeOn = true;
-
-    //if (getCursorOn())
-    //{
-    //    removeCursorDisplay(); // before doing anything we need to remove the cursor if it is on
-    //    cursorOn = false;
-    //}
-
     m_copy.first = Mask2dType::New();
 
     m_copy.first->SetRegions(region);
@@ -1846,9 +1714,6 @@ void AlgorithmPaintToolbox::pasteSliceMask()
     listIdSlice.append(slice);
     addSliceToStack(currentView,planeIndex,listIdSlice);
     // -------------------------------------------------
-
-    //if (cursorOn)
-    //    cursorJustReactivated = true;
 
     pasteSliceToMask3D(m_copy.first,planeIndex,direction,slice);
 
@@ -1964,35 +1829,6 @@ void AlgorithmPaintToolbox::pasteSliceToMask3D(const itk::Image<unsigned char,2>
     }
 }
 
-void AlgorithmPaintToolbox::removeCursorDisplay()
-{
-//    if (!currentView)
-//        return;
-//
-//    /*if (!currentStateForCursor)
-//        return;*/
-//    
-//    /*unsigned int i, j;
-//    char direction[2];
-//    for (i = 0, j = 0; i < 3; ++i )
-//    {
-//        if (i != currentPlaneIndex)
-//        {
-//            direction[j] = i;
-//            j++;
-//        }
-//    }
-//*/
-//    //pasteSliceToMask3D(currentStateForCursor,currentPlaneIndex,direction,currentIdSlice);
-//    for(int i = 0;i<cursorPixels->size();i++)
-//        m_itkMask->SetPixel(cursorPixels->at(i).first,cursorPixels->at(i).second);
-//
-//    m_itkMask->Modified();
-//    m_itkMask->GetPixelContainer()->Modified();
-//    m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
-//    m_maskAnnotationData->invokeModified();
-}
-
 void AlgorithmPaintToolbox::increaseBrushSize()
 {
     addBrushSize(1);
@@ -2010,23 +1846,10 @@ void AlgorithmPaintToolbox::reduceBrushSize()
     addBrushSize(-1);
     if (!currentView)
         return;
-    //if (cursorOn && !cursorJustReactivated)
-    //{
-    //    //removeCursorDisplay();
-    //    updateStroke(m_viewFilter,currentView);
-    //}
 }
 
 void AlgorithmPaintToolbox::setCursorOn(bool value)
 {
-    //if (!currentView)
-    //    return;
-    //cursorOn = value;
-    /*if (value)
-        if (m_paintState != PaintState::DeleteStroke)
-            currentView->setProperty("Cursor","None");  
-    else
-        currentView->setProperty("Cursor","Normal");*/
 }
 
 void AlgorithmPaintToolbox::interpolate()

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -97,21 +97,6 @@ public:
             return false;
         m_cb->setCurrentView(imageView);
 
-        //// let's take the first non medImageMaskAnnotationData as the reference data
-        //// TODO: to improve...
-        //for(unsigned int i=0; i<imageView->layersCount(); i++)
-        //{
-        //    medAbstractData *data = imageView->layerData(i);
-        //    if (!data)
-        //        continue;
-
-        //    medImageMaskAnnotationData * existingMaskAnnData = dynamic_cast<medImageMaskAnnotationData *>(data);
-        //    if(!existingMaskAnnData)
-        //    {
-        //        m_cb->setData( data );
-        //        break;
-        //    }
-        //}
         if (imageView->is2D())
         {
             // Convert mouse click to a 3D point in the image.
@@ -662,7 +647,7 @@ void AlgorithmPaintToolbox::updateView()
     //                     //  on the view as long as the setData is not called for this view
     if (currentView)
     {
-        medAbstractData* data = currentView->layerData(currentView->currentLayer());
+        medAbstractData* data = currentView->layerData(0);
         if(!data)
             return;
         medImageMaskAnnotationData * existingMaskAnnData = dynamic_cast<medImageMaskAnnotationData *>(data);
@@ -711,7 +696,6 @@ void AlgorithmPaintToolbox::clearMask()
         {
             m_imageData->removeAttachedData(m_maskAnnotationData);
             maskHasBeenSaved = false;
-            //HACKKKKKK
             setData(currentView->layerData(0));
         }
     }
@@ -909,7 +893,7 @@ void AlgorithmPaintToolbox::updateWandRegion(medAbstractImageView * view, QVecto
    
     if ( !m_imageData )
     {
-        this->setData(view->layerData(view->currentLayer()));
+        this->setData(view->layerData(0));
     }
     if (!m_imageData) {
         dtkWarn() << "Could not set data";
@@ -1113,7 +1097,7 @@ void AlgorithmPaintToolbox::updateStroke(ClickAndMoveEventFilter * filter, medAb
     const double radius = m_strokeRadius; // in image units.
 
     if ( !m_imageData ) {
-        this->setData(view->layerData(view->currentLayer()));
+        this->setData(view->layerData(0));
     }
     if (!m_imageData) {
         dtkWarn() << "Could not set data";

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -69,6 +69,10 @@ public:
 
     virtual bool mousePressEvent(medAbstractView *view, QMouseEvent *mouseEvent )
     {
+        bool shouldWeRetrieveData = true;
+        if(m_paintState == m_cb->paintState())
+            shouldWeRetrieveData = false;
+
         m_paintState = m_cb->paintState();
 
         if ( this->m_paintState == PaintState::DeleteStroke )
@@ -97,22 +101,21 @@ public:
             return false;
         m_cb->setCurrentView(imageView);
 
-        // let's take the first non medImageMaskAnnotationData as the reference data
-        // TODO: to improve...
-        foreach(medDataIndex index, imageView->dataList())
-        {
-            medAbstractData *data = medDataManager::instance()->retrieveData(index);
-            if (!data)
-                continue;
+        //// let's take the first non medImageMaskAnnotationData as the reference data
+        //// TODO: to improve...
+        //for(unsigned int i=0; i<imageView->layersCount(); i++)
+        //{
+        //    medAbstractData *data = imageView->layerData(i);
+        //    if (!data)
+        //        continue;
 
-            medImageMaskAnnotationData * existingMaskAnnData = dynamic_cast<medImageMaskAnnotationData *>(data);
-            if(!existingMaskAnnData)
-            {
-                m_cb->setData( data );
-                break;
-            }
-        }
-        
+        //    medImageMaskAnnotationData * existingMaskAnnData = dynamic_cast<medImageMaskAnnotationData *>(data);
+        //    if(!existingMaskAnnData)
+        //    {
+        //        m_cb->setData( data );
+        //        break;
+        //    }
+        //}
         if (imageView->is2D())
         {
             // Convert mouse click to a 3D point in the image.
@@ -154,53 +157,55 @@ public:
         medAbstractImageView * imageView = dynamic_cast<medAbstractImageView *>(view);
         if(!imageView)
             return false;
-		
-		if (m_paintState == PaintState::None && (m_cb->m_paintState == PaintState::Stroke || m_cb->m_paintState == PaintState::DeleteStroke) && (m_cb->getCursorOn() || m_cb->undoRedoCopyPasteModeOn))
+
+        if (m_paintState == PaintState::None 
+            && (m_cb->m_paintState == PaintState::Stroke || m_cb->m_paintState == PaintState::DeleteStroke) 
+            && (/*m_cb->getCursorOn() ||*/ m_cb->undoRedoCopyPasteModeOn))
         {
             //m_cb->undoRedoCopyPasteModeOn = false;
             //m_cb->setCursorOn(true);
             mouseEvent->accept();
-            
+
             int elapsed = timer.elapsed();
 
             qDebug() << elapsed;
             if (elapsed<10) // 1000/24 (24 images per second)
                 return false;
 
-            if (!m_cb->cursorJustReactivated )
-                m_cb->removeCursorDisplay();  
-            else
-                m_cb->cursorJustReactivated  = false;
+            //if (!m_cb->cursorJustReactivated )
+            //    m_cb->removeCursorDisplay();  
+            //else
+            //    m_cb->cursorJustReactivated  = false;
 
             if (imageView->is2D())
             {
                 QVector3D posImage = imageView->mapDisplayToWorldCoordinates( mouseEvent->posF() );
-            
+
                 bool isInside;
                 MaskType::IndexType index;
                 unsigned int planeIndex = m_cb->computePlaneIndex(posImage,index,isInside);
                 unsigned int idSlice = index[planeIndex];
-                
+
                 if (planeIndex != m_cb->getCurrentPlaneIndex() || idSlice != m_cb->getCurrentIdSlice())
                 {
                     m_cb->setCurrentPlaneIndex(planeIndex);
                     m_cb->setCurrentIdSlice(idSlice);
                 }
-               
+
                 //Project vector onto plane
                 this->m_points.push_back(posImage);
                 m_cb->updateStroke( this,imageView );
                 timer.start();
             }
-           return mouseEvent->isAccepted();
+            return mouseEvent->isAccepted();
         }
-		
+
         if ( this->m_paintState == PaintState::None )
             return false;
-		
-		m_cb->setCursorOn(false); 
+
+        //m_cb->setCursorOn(false); 
         mouseEvent->accept();
-	
+
         if (imageView->is2D())
         {
             QVector3D posImage = imageView->mapDisplayToWorldCoordinates( mouseEvent->posF() );
@@ -224,8 +229,8 @@ public:
         {
             m_paintState = PaintState::None; //Painting is done
             m_cb->updateStroke(this, imageView);
-            m_cb->setCursorOn(true);
-            m_cb->cursorJustReactivated  = true;
+            //m_cb->setCursorOn(true);
+            //m_cb->cursorJustReactivated  = true;
             this->m_points.clear();
             timer.start();
             return true;
@@ -248,11 +253,11 @@ public:
             else 
                 m_cb->addBrushSize(numSteps);
             
-            if (!m_cb->cursorJustReactivated && m_paintState!=PaintState::Stroke )
-            {
-                m_cb->removeCursorDisplay();
-                m_cb->updateStroke(this,imageView);
-            }
+            //if (!m_cb->cursorJustReactivated && m_paintState!=PaintState::Stroke )
+            //{
+            //    //m_cb->removeCursorDisplay();
+            //    m_cb->updateStroke(this,imageView);
+            //}
             return true;   
         }
         return false;
@@ -264,11 +269,11 @@ public:
             view->setProperty("Cursor","Normal");
         else
             return false;*/
-        if (!m_cb->getCursorOn())
-            return false;
+        //if (!m_cb->getCursorOn())
+        //    return false;
         
-        m_cb->removeCursorDisplay();
-        m_cb->cursorJustReactivated  = true;
+        //m_cb->removeCursorDisplay();
+        //m_cb->cursorJustReactivated  = true;
 
         return true;
     }
@@ -513,12 +518,12 @@ AlgorithmPaintToolbox::AlgorithmPaintToolbox(QWidget *parent ) :
     m_undoStacks = new QHash<medAbstractView*,QStack<PairListSlicePlaneId>*>();
     m_redoStacks = new QHash<medAbstractView*,QStack<PairListSlicePlaneId>*>();
 
-    cursorOn = false;
-    cursorPixels = new QList<QPair<MaskType::IndexType,unsigned char> >();
+    //cursorOn = false;
+    //cursorPixels = new QList<QPair<MaskType::IndexType,unsigned char> >();
     currentPlaneIndex = 0;
     currentIdSlice = 0;
     undoRedoCopyPasteModeOn = false;
-    cursorJustReactivated = true;
+    //cursorJustReactivated = true;
     currentView = 0;
 
     //Shortcuts
@@ -760,6 +765,8 @@ void AlgorithmPaintToolbox::clearMask()
         {
             m_imageData->removeAttachedData(m_maskAnnotationData);
             maskHasBeenSaved = false;
+            //HACKKKKKK
+            setData(currentView->layerData(0));
         }
     }
 }
@@ -1528,11 +1535,11 @@ void AlgorithmPaintToolbox::redo()
 
     //undoRedoCopyPasteModeOn = true;
 
-    if (getCursorOn())
-    {
-        removeCursorDisplay(); // before doing anything we need to remove the cursor if it is on
-        cursorOn = false;
-    }
+    //if (getCursorOn())
+    //{
+    //    /removeCursorDisplay(); // before doing anything we need to remove the cursor if it is on
+    //    cursorOn = false;
+    //}
 
     QList<SlicePair> list;
     for(int i = 0;i<nextState.first.length();i++)
@@ -1789,11 +1796,11 @@ void AlgorithmPaintToolbox::copySliceMask()
 
     //undoRedoCopyPasteModeOn = true;
 
-    if (getCursorOn())
-    {
-        removeCursorDisplay(); // before doing anything we need to remove the cursor if it is on
-        cursorOn = false;
-    }
+    //if (getCursorOn())
+    //{
+    //    removeCursorDisplay(); // before doing anything we need to remove the cursor if it is on
+    //    cursorOn = false;
+    //}
 
     m_copy.first = Mask2dType::New();
 
@@ -1840,8 +1847,8 @@ void AlgorithmPaintToolbox::pasteSliceMask()
     addSliceToStack(currentView,planeIndex,listIdSlice);
     // -------------------------------------------------
 
-    if (cursorOn)
-        cursorJustReactivated = true;
+    //if (cursorOn)
+    //    cursorJustReactivated = true;
 
     pasteSliceToMask3D(m_copy.first,planeIndex,direction,slice);
 
@@ -1959,31 +1966,31 @@ void AlgorithmPaintToolbox::pasteSliceToMask3D(const itk::Image<unsigned char,2>
 
 void AlgorithmPaintToolbox::removeCursorDisplay()
 {
-    if (!currentView)
-        return;
-
-    /*if (!currentStateForCursor)
-        return;*/
-    
-    /*unsigned int i, j;
-    char direction[2];
-    for (i = 0, j = 0; i < 3; ++i )
-    {
-        if (i != currentPlaneIndex)
-        {
-            direction[j] = i;
-            j++;
-        }
-    }
-*/
-    //pasteSliceToMask3D(currentStateForCursor,currentPlaneIndex,direction,currentIdSlice);
-    for(int i = 0;i<cursorPixels->size();i++)
-        m_itkMask->SetPixel(cursorPixels->at(i).first,cursorPixels->at(i).second);
-
-    m_itkMask->Modified();
-    m_itkMask->GetPixelContainer()->Modified();
-    m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
-    m_maskAnnotationData->invokeModified();
+//    if (!currentView)
+//        return;
+//
+//    /*if (!currentStateForCursor)
+//        return;*/
+//    
+//    /*unsigned int i, j;
+//    char direction[2];
+//    for (i = 0, j = 0; i < 3; ++i )
+//    {
+//        if (i != currentPlaneIndex)
+//        {
+//            direction[j] = i;
+//            j++;
+//        }
+//    }
+//*/
+//    //pasteSliceToMask3D(currentStateForCursor,currentPlaneIndex,direction,currentIdSlice);
+//    for(int i = 0;i<cursorPixels->size();i++)
+//        m_itkMask->SetPixel(cursorPixels->at(i).first,cursorPixels->at(i).second);
+//
+//    m_itkMask->Modified();
+//    m_itkMask->GetPixelContainer()->Modified();
+//    m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
+//    m_maskAnnotationData->invokeModified();
 }
 
 void AlgorithmPaintToolbox::increaseBrushSize()
@@ -1991,11 +1998,11 @@ void AlgorithmPaintToolbox::increaseBrushSize()
     addBrushSize(1);
     if (!currentView)
         return;
-    if (cursorOn && !cursorJustReactivated) 
-    {
-        removeCursorDisplay();
-        updateStroke(m_viewFilter,currentView);
-    }
+    //if (cursorOn && !cursorJustReactivated) 
+    //{
+        //removeCursorDisplay();
+        //updateStroke(m_viewFilter,currentView);
+    //}
 }
 
 void AlgorithmPaintToolbox::reduceBrushSize()
@@ -2003,11 +2010,11 @@ void AlgorithmPaintToolbox::reduceBrushSize()
     addBrushSize(-1);
     if (!currentView)
         return;
-    if (cursorOn && !cursorJustReactivated)
-    {
-        removeCursorDisplay();
-        updateStroke(m_viewFilter,currentView);
-    }
+    //if (cursorOn && !cursorJustReactivated)
+    //{
+    //    //removeCursorDisplay();
+    //    updateStroke(m_viewFilter,currentView);
+    //}
 }
 
 void AlgorithmPaintToolbox::setCursorOn(bool value)

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
@@ -77,8 +77,6 @@ public:
     void setSeedPlanted(bool,MaskType::IndexType,unsigned int,double);
     void setSeed(QVector3D);
 
-    inline bool getCursorOn(){return cursorOn;};
-    void setCursorOn(bool value);
     inline void setCurrentIdSlice(unsigned int id){currentIdSlice = id;};
     inline unsigned int getCurrentIdSlice(){return currentIdSlice;};
     inline void setCurrentPlaneIndex(unsigned int index){currentPlaneIndex = index;};
@@ -121,7 +119,6 @@ public slots:
     void undo();
     void redo();
     void addSliceToStack(medAbstractView * view,const unsigned char planeIndex,QList<int> listIdSlice);
-    //void saveCurrentStateForCursor(medAbstractView * view,const unsigned char planeIndex,unsigned int idSlice);
     void onViewClosed();
 
     void newSeed();
@@ -164,8 +161,6 @@ protected:
 
     void copySliceFromMask3D(itk::Image<unsigned char,2>::Pointer copy,const char planeIndex,const char * direction,const unsigned int slice);
     void pasteSliceToMask3D(itk::Image<unsigned char,2>::Pointer image2D,const char planeIndex,const char * direction,const unsigned int slice);
-
-    void removeCursorDisplay();
 
 signals:
     void installEventFilterRequest(medViewEventFilter *filter);
@@ -238,12 +233,9 @@ private:
     medAbstractImageView* currentView;
     medAbstractImageView * viewCopied;
 
-    bool cursorOn;
-    QList<QPair<MaskType::IndexType,unsigned char> > * cursorPixels;
     unsigned int currentPlaneIndex; //plane Index of the current/last operation
     unsigned int currentIdSlice; // current slice;
     bool undoRedoCopyPasteModeOn;
-    bool cursorJustReactivated;
 
     template <typename IMAGE> void RunConnectedFilter (MaskType::IndexType &index, unsigned int planeIndex);
     template <typename IMAGE> void GenerateMinMaxValuesFromImage ();


### PR DESCRIPTION
In your current version of Paint Segmentation, every time you click on the volume (for painting) the algo goes through every layer of the view and checks whether the layer has already been painted. If not, it sets the data.
This loop is really slowing down the painting; after each click, there is half-second "freeze" during which the motion of the mouse is not taken into account; which makes the use of the tool quite disturbing/annoying.

What I did was removing this loop and setting the data in the clearMask method, because I think the only times you need to set the data is when you change the data (managed by updateView) or when you reset your mask after saving it (meaning that you want to start a new segmentation, thus create a new mask).

I decided to get rid of the multi-layer management because I am not sure it's actually needed (I don't think anybody uses that) and because it was giving me some trouble while trying to improve the paint reactivity (that was the first reason I must confess).