### PR TITLE
Adds new method values(QString) to medCompositeParameter

### DIFF
--- a/src/medCore/parameters/medCompositeParameter.cpp
+++ b/src/medCore/parameters/medCompositeParameter.cpp
@@ -132,6 +132,11 @@ QList<QVariant> medCompositeParameter::values() const
     return d->variants.values();
 }
 
+QList<QVariant> medCompositeParameter::values( const QString key) const
+{
+    return d->variants.values(key);
+}
+
 void medCompositeParameter::updateInternWigets()
 {
     QHash<QString, QVariant>::const_iterator i = d->variants.constBegin();

--- a/src/medCore/parameters/medCompositeParameter.cpp
+++ b/src/medCore/parameters/medCompositeParameter.cpp
@@ -132,9 +132,9 @@ QList<QVariant> medCompositeParameter::values() const
     return d->variants.values();
 }
 
-QList<QVariant> medCompositeParameter::values( const QString key) const
+QVariant medCompositeParameter::value( const QString key) const
 {
-    return d->variants.values(key);
+    return d->variants[key];
 }
 
 void medCompositeParameter::updateInternWigets()

--- a/src/medCore/parameters/medCompositeParameter.h
+++ b/src/medCore/parameters/medCompositeParameter.h
@@ -34,7 +34,7 @@ public:
                     QVariant min = QVariant(0), QVariant max = QVariant(100), QVariant step = QVariant(1));
 
     virtual QList<QVariant> values() const;
-    virtual QList<QVariant> values(const QString) const;
+    virtual QVariant value(const QString) const;
     QList<QPair <QVariant, QVariant> > ranges() const;
     QList<QVariant> steps() const;
 

--- a/src/medCore/parameters/medCompositeParameter.h
+++ b/src/medCore/parameters/medCompositeParameter.h
@@ -34,6 +34,7 @@ public:
                     QVariant min = QVariant(0), QVariant max = QVariant(100), QVariant step = QVariant(1));
 
     virtual QList<QVariant> values() const;
+    virtual QList<QVariant> values(const QString) const;
     QList<QPair <QVariant, QVariant> > ranges() const;
     QList<QVariant> steps() const;
 


### PR DESCRIPTION
With the current *values()* method, the QList returned comes from *QHash::values()*; its order is arbitrary.
We had this problem in MUSIC (https://github.com/Inria-Asclepios/music/pull/30) where we wanted to get the windowing parameters through the *windowLevelParameter* but we were not able to be sure whether the level would come first (in the QList) or the window width ...
So I created a new *medCompositeParameter::values(QString)* method which takes the key of the hash as argument.
Now, to have the window level we just use *compositeParameter->values("Level")[0]*