### PR TITLE
Paint fix

### DIFF
--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -429,7 +429,8 @@ AlgorithmPaintToolbox::AlgorithmPaintToolbox(QWidget *parent ) :
     connect (m_strokeButton, SIGNAL(pressed()), this, SLOT(activateStroke ()));
     connect (m_magicWandButton, SIGNAL(pressed()),this,SLOT(activateMagicWand()));
     connect (m_clearMaskButton, SIGNAL(pressed()), this, SLOT(clearMask()));
-    connect (m_applyButton, SIGNAL(pressed()),this, SLOT(import()));
+    connect (m_applyButton, SIGNAL(pressed()),this, SLOT(save()));
+    connect(this, SIGNAL(save(medAbstractData*)), this, SLOT(import(medAbstractData*)));
     connect(this->segmentationToolBox(), SIGNAL(inputChanged()), this, SLOT(updateMouseInteraction()));
 
     connect (m_interpolateButton, SIGNAL(clicked()),
@@ -611,13 +612,15 @@ void AlgorithmPaintToolbox::updateMagicWandComputationSpeed()
     }
 }
 
-void AlgorithmPaintToolbox::import()
-{  
-    m_maskData->copyMetaDataFrom(m_imageData);
-    QString newSeriesDescription = m_imageData->metadata ( medMetaDataKeys::SeriesDescription.key() ) + " painted";
-    m_maskData->setMetaData ( medMetaDataKeys::SeriesDescription.key(), newSeriesDescription );
-    medDataManager::instance()->importData(m_maskData, true);
+void AlgorithmPaintToolbox::save()
+{
+    emit save(m_maskData);
     maskHasBeenSaved = true;
+}
+
+void AlgorithmPaintToolbox::import(medAbstractData* data)
+{
+    medDataManager::instance()->importData(data, true);
 }
 
 void AlgorithmPaintToolbox::setWorkspace(medAbstractWorkspace* workspace)
@@ -659,7 +662,7 @@ void AlgorithmPaintToolbox::updateView()
         medImageMaskAnnotationData * existingMaskAnnData = dynamic_cast<medImageMaskAnnotationData *>(data);
         if(!existingMaskAnnData)
         {
-            setData( data );
+            updateData();
         }
     }
 }
@@ -702,26 +705,17 @@ void AlgorithmPaintToolbox::clearMask()
         {
             m_imageData->removeAttachedData(m_maskAnnotationData);
             maskHasBeenSaved = false;
-            setData(currentView->layerData(0));
+            updateData();
         }
     }
 }
 
-void AlgorithmPaintToolbox::setData( medAbstractData *medData )
+void AlgorithmPaintToolbox::updateData()
 {
-    if (!medData)
-        return;
-
-    // disconnect existing
-    if ( m_imageData )
-    {
-        // TODO?
-    }
-
     m_lastVup = QVector3D();
     m_lastVpn = QVector3D();
 
-    m_imageData = medData;
+    m_imageData = currentView->layerData(0);
 
     // Update values of slider
 
@@ -752,7 +746,6 @@ void AlgorithmPaintToolbox::setData( medAbstractData *medData )
             m_maskData = existingMaskAnnData->maskData();
 
         } else {
-
             m_maskData =
                 medAbstractDataFactory::instance()->createSmartPointer( "itkDataImageUChar3" );
 
@@ -768,6 +761,10 @@ void AlgorithmPaintToolbox::setData( medAbstractData *medData )
             m_maskAnnotationData->setColorMap( m_labelColorMap );
 
             m_imageData->addAttachedData(m_maskAnnotationData);
+
+            currentView->addLayer(m_maskAnnotationData);
+
+            setMaskMetaData();
         }
     }
 
@@ -778,6 +775,17 @@ void AlgorithmPaintToolbox::setData( medAbstractData *medData )
         m_itkMask = NULL;
         this->showButtons(false);
     }
+}
+
+void AlgorithmPaintToolbox::setMaskMetaData()
+{
+    m_maskData->copyMetaDataFrom(m_imageData);
+
+    QString newSeriesDescription = m_imageData->metadata(medMetaDataKeys::SeriesDescription.key()) + " (painted)";
+    m_maskData->setMetaData(medMetaDataKeys::SeriesDescription.key(), newSeriesDescription);
+
+    QString generatedSeriesID = QUuid::createUuid().toString().replace("{", "").replace("}", "");
+    m_maskData->setMetaData(medMetaDataKeys::SeriesID.key(), generatedSeriesID);
 }
 
 void AlgorithmPaintToolbox::generateLabelColorMap(unsigned int numLabels)
@@ -899,7 +907,7 @@ void AlgorithmPaintToolbox::updateWandRegion(medAbstractImageView * view, QVecto
    
     if ( !m_imageData )
     {
-        this->setData(view->layerData(0));
+        this->updateData();
     }
     if (!m_imageData) {
         dtkWarn() << "Could not set data";
@@ -932,16 +940,6 @@ void AlgorithmPaintToolbox::updateWandRegion(medAbstractImageView * view, QVecto
         RunConnectedFilter < itk::Image <float,3> > (index,planeIndex);
         RunConnectedFilter < itk::Image <double,3> > (index,planeIndex);
     }
-
-    if(!view->contains(m_maskAnnotationData))
-    {
-        view->addLayer(m_maskAnnotationData);
-        m_maskData->copyMetaDataFrom(m_imageData);
-        QString newSeriesDescription = m_imageData->metadata ( medMetaDataKeys::SeriesDescription.key() ) + " painted";
-        m_maskData->setMetaData ( medMetaDataKeys::SeriesDescription.key(), newSeriesDescription );
-        medDataManager::instance()->importData(m_maskData);
-    }
-
 }
 
 template <typename IMAGE>
@@ -1101,7 +1099,7 @@ void AlgorithmPaintToolbox::updateStroke(ClickAndMoveEventFilter * filter, medAb
     const double radius = m_strokeRadius; // in image units.
 
     if ( !m_imageData ) {
-        this->setData(view->layerData(0));
+        this->updateData();
     }
     if (!m_imageData) {
         dtkWarn() << "Could not set data";
@@ -1203,15 +1201,6 @@ void AlgorithmPaintToolbox::updateStroke(ClickAndMoveEventFilter * filter, medAb
     m_itkMask->Modified();
     m_itkMask->GetPixelContainer()->Modified();
     m_itkMask->SetPipelineMTime(m_itkMask->GetMTime());
-
-    if(!view->contains(m_maskAnnotationData))
-    {
-        view->addLayer(m_maskAnnotationData);
-        m_maskData->copyMetaDataFrom(m_imageData);
-        QString newSeriesDescription = m_imageData->metadata ( medMetaDataKeys::SeriesDescription.key() ) + " painted";
-        m_maskData->setMetaData ( medMetaDataKeys::SeriesDescription.key(), newSeriesDescription );
-        medDataManager::instance()->importData(m_maskData);
-    }
 
     m_maskAnnotationData->invokeModified();
 }

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -762,6 +762,7 @@ void AlgorithmPaintToolbox::updateData()
 
             m_imageData->addAttachedData(m_maskAnnotationData);
 
+            currentView->removeLayer(1);
             currentView->addLayer(m_maskAnnotationData);
 
             setMaskMetaData();
@@ -781,7 +782,10 @@ void AlgorithmPaintToolbox::setMaskMetaData()
 {
     m_maskData->copyMetaDataFrom(m_imageData);
 
-    QString newSeriesDescription = m_imageData->metadata(medMetaDataKeys::SeriesDescription.key()) + " (painted)";
+    QString newSeriesDescription = m_imageData->metadata(medMetaDataKeys::SeriesDescription.key()) + " (painted) ";
+    QString seriesSuffix = QString::number(qrand());
+    seriesSuffix.resize(importNameRandomSuffixSize);
+    newSeriesDescription += seriesSuffix;
     m_maskData->setMetaData(medMetaDataKeys::SeriesDescription.key(), newSeriesDescription);
 
     QString generatedSeriesID = QUuid::createUuid().toString().replace("{", "").replace("}", "");

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
@@ -60,6 +60,8 @@ class MEDVIEWSEGMENTATIONPLUGIN_EXPORT AlgorithmPaintToolbox : public medSegment
     MED_TOOLBOX_INTERFACE("AlgorithmPaintToolbox", "Paint Tool",
                           <<"segmentation")
 public:
+
+    static const int importNameRandomSuffixSize = 5;
     
     typedef QPair<Mask2dType::Pointer,unsigned int> SlicePair;
     typedef QPair<QList<SlicePair>,unsigned char> PairListSlicePlaneId;

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
@@ -103,7 +103,9 @@ public slots:
     void activateMagicWand();
     void updateMagicWandComputationSpeed();
 
-    void import();
+    void save();
+
+    void import(medAbstractData* data);
     void clearMask();
 
     void setLabel(int newVal);
@@ -138,7 +140,9 @@ protected:
     friend class ClickAndMoveEventFilter;
     
     void addStroke( medAbstractImageView *view, const QVector3D &vec );
-    void setData( medAbstractData *data );
+    void updateData();
+
+    void setMaskMetaData();
 
     // update with seed point data.
     void updateTableRow(int row);
@@ -162,6 +166,7 @@ protected:
 
 signals:
     void installEventFilterRequest(medViewEventFilter *filter);
+    void save(medAbstractData* data);
 
 private:
     typedef dtkSmartPointer<medSeedPointAnnotationData> SeedPoint;


### PR DESCRIPTION
The PR corrects import-related bugs (and will be complemented by a music-side PR for the pipeline)
I was asked to change the toolbox as little as possible.
It changes the following :
- No more annoying pauses when starting to paint due to layer creation
- No more unwanted imports when painting or using magic wand
- Imported masks now have their seriesId properly generated
- Imported masks have a random suffix added to their name so that the user is not forced to rename the file if they don't want the next save to erase the previous one.
- I added an intermediate step (using signals and slots) between clicking on the button Save and importing. This will be used in the pipeline to avoid importing and retrieve the data directly.