### PR TITLE
Adds Min/Max range as linkable parameters for meshes

### DIFF
--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -257,7 +257,9 @@ void vtkDataMeshInteractor::setupParameters()
     d->parameters << this->visibilityParameter();
 
     d->minRange = new medDoubleParameter("Min",this);
+    d->parameters << d->minRange;
     d->maxRange = new medDoubleParameter("Max",this);
+    d->parameters << d->maxRange;
 
     connect(d->minRange,SIGNAL(valueChanged(double)),this,SLOT(updateRange()));
     connect(d->maxRange,SIGNAL(valueChanged(double)),this,SLOT(updateRange()));


### PR DESCRIPTION
Needed if we want to automatically set intensity range when displaying a mesh (only the linkable parameters are, for now, accessible)

Either we set min/MaxRange as linkable parameters, or we create a new method that returns all the parameters of an interactor.