### PR TITLE
ToolBox header color & layers name color

### DIFF
--- a/app/medInria/resources/medInria.qrc
+++ b/app/medInria/resources/medInria.qrc
@@ -1,157 +1,157 @@
 <RCC>
-<qresource prefix="/">
-<file>../../../LICENSE.txt</file>
-<file>../../../RELEASE_NOTES.txt</file>
-<file>medInria.ico</file>
-<file>music_logo.png</file>
-<file>music_logo_small.png</file>
-<file>icons/AxialIcon.png</file>
-<file>icons/CoronalIcon.png</file>
-<file>icons/SagittalIcon.png</file>
-<file>icons/3DIcon.png</file>
-<file>icons/about.png</file>
-<file>icons/quit.png</file>
-<file>icons/cog.png</file>
-<file>icons/camera.png</file>
-<file>icons/camera_grey.png</file>
-<file>icons/cropping.png</file>
-<file>icons/database.png</file>
-<file>icons/home_sc.png</file>
-<file>icons/workspace_Diffusion.png</file>
-<file>icons/workspace_Visualization.png</file>
-<file>icons/workspace_Registration.png</file>
-<file>icons/workspace_Filtering.png</file>
-<file>icons/workspace_Segmentation.png</file>
-<file>icons/folder.png</file>
-<file>icons/home.png</file>
-<file>icons/error.png</file>
-<file>icons/error_add.png</file>
-<file>icons/error_delete.png</file>
-<file>icons/error_go.png</file>
-<file>icons/exclamation.png</file>
-<file>icons/eye.png</file>
-<file>icons/help.png</file>
-<file>icons/help.svg</file>
-<file>icons/information.png</file>
-<file>icons/layer.png</file>
-<file>icons/length.png</file>
-<file>icons/lightbulb.png</file>
-<file>icons/lightbulb_add.png</file>
-<file>icons/lightbulb_delete.png</file>
-<file>icons/lightbulb_off.png</file>
-<file>icons/lightning.png</file>
-<file>icons/lightning_add.png</file>
-<file>icons/lightning_delete.png</file>
-<file>icons/lightning_go.png</file>
-<file>icons/link.png</file>
-<file>icons/link_add.png</file>
-<file>icons/link_break.png</file>
-<file>icons/link_delete.png</file>
-<file>icons/link_edit.png</file>
-<file>icons/link_error.png</file>
-<file>icons/link_go.png</file>
-<file>icons/link_wl.png</file>
-<file>icons/lock.png</file>
-<file>icons/lock_add.png</file>
-<file>icons/lock_break.png</file>
-<file>icons/lock_delete.png</file>
-<file>icons/lock_edit.png</file>
-<file>icons/lock_go.png</file>
-<file>icons/lock_open.png</file>
-<file>icons/magnify.png</file>
-<file>icons/magifier_zoom_out.png</file>
-<file>icons/magnifier.png</file>
-<file>icons/magnifier_zoom_in.png</file>
-<file>icons/medCustomViewContainerA.png</file>
-<file>icons/medCustomViewContainerB.png</file>
-<file>icons/medCustomViewContainerC.png</file>
-<file>icons/medCustomViewContainerD.png</file>
-<file>icons/medCustomViewContainerE.png</file>
-<file>icons/medCustomViewContainerF.png</file>
-<file>icons/mouse.png</file>
-<file>icons/mouse_add.png</file>
-<file>icons/mouse_delete.png</file>
-<file>icons/mouse_error.png</file>
-<file>icons/page_add.png</file>
-<file>icons/page_edit.png</file>
-<file>icons/page_white_copy.png</file>
-<file>icons/page_white_database.png</file>
-<file>icons/page_white_delete.png</file>
-<file>icons/page_white_dvd.png</file>
-<file>icons/page_white_error.png</file>
-<file>icons/page_white_gear.png</file>
-<file>icons/page_white_get.png</file>
-<file>icons/page_white_go.png</file>
-<file>icons/page_white_key.png</file>
-<file>icons/page_white_lightning.png</file>
-<file>icons/page_white_link.png</file>
-<file>icons/page_white_magnify.png</file>
-<file>icons/page_white_put.png</file>
-<file>icons/page_white_stack.png</file>
-<file>icons/settings.svg</file>
-<file>icons/stack.png</file>
-<file>icons/widget.png</file>
-<file>icons/wlww.png</file>
-<file>icons/zoom.png</file>
-<file>icons/zoom_in.png</file>
-<file>icons/zoom_out.png</file>
-<file>icons/backward.png</file>
-<file>icons/forward.png</file>
-<file>icons/star.svg</file>
-<file>icons/user_add.png</file>
-<file>icons/user_edit.png</file>
-<file>medInria.qss</file>
-<file>pixmaps/unknown.jpg</file>
-<file>pixmaps/checkbox.png</file>
-<file>pixmaps/checkbox-checked.png</file>
-<file>pixmaps/checkbox-partial.png</file>
-<file>pixmaps/radio.png</file>
-<file>pixmaps/radio-checked.png</file>
-<file>pixmaps/radio-partial.png</file>
-<file>pixmaps/drop-down.png</file>
-<file>pixmaps/treeview-branch-closed.png</file>
-<file>pixmaps/treeview-branch-open.png</file>
-<file>pixmaps/database_navigator_item_checker_checked.png</file>
-<file>pixmaps/database_navigator_item_checker_unchecked.png</file>
-<file>pixmaps/medInria-logo-homepage.png</file>
-<file>pixmaps/medInria-splash.png</file>
-<file>pixmaps/delete.png</file>
-<file>icons/settings.png</file>
-<file>icons/stop.png</file>
-<file>icons/pause.png</file>
-<file>icons/play.png</file>
-<file>authors.html</file>
-<file>icons/fullscreenExpand.png</file>
-<file>icons/fullscreenReduce.png</file>
-<file>icons/medInriaPlugin.png</file>
-<file>icons/import.png</file>
-<file>icons/export.png</file>
-<file>icons/load.svg</file>
-<file>icons/export.svg</file>
-<file>icons/save.svg</file>
-<file>icons/save.png</file>
-<file>icons/magnifier.svg</file>
-<file>icons/cross.svg</file>
-<file>icons/finger.png</file>
-<file>icons/document-open.png</file>
-<file>icons/maximize.svg</file>
-<file>icons/whitecross.svg</file>
-<file>icons/link.svg</file>
-<file>icons/broken_link.svg</file>
-<file>icons/un_maximize.svg</file>
-<file>pixmaps/radio-disabled.png</file>
-<file>pixmaps/radio-checked-disabled.png</file>
-<file>pixmaps/plus-button.png</file>
-<file>pixmaps/checkbox-disabled.png</file>
-<file>pixmaps/checkbox-checked-disabled.png</file>
-<file>pixmaps/arrow-top-disabled.png</file>
-<file>pixmaps/arrow-top.png</file>
-<file>pixmaps/arrow-right-disabled.png</file>
-<file>pixmaps/arrow-right.png</file>
-<file>pixmaps/arrow-left-disabled.png</file>
-<file>pixmaps/arrow-left.png</file>
-<file>pixmaps/arrow-bot-disabled.png</file>
-<file>pixmaps/arrow-bot.png</file>
-<file>icons/adjust_size.png</file>
-</qresource>
+    <qresource prefix="/">
+        <file>../../../LICENSE.txt</file>
+        <file>../../../RELEASE_NOTES.txt</file>
+        <file>medInria.ico</file>
+        <file>music_logo.png</file>
+        <file>music_logo_small.png</file>
+        <file>icons/AxialIcon.png</file>
+        <file>icons/CoronalIcon.png</file>
+        <file>icons/SagittalIcon.png</file>
+        <file>icons/3DIcon.png</file>
+        <file>icons/about.png</file>
+        <file>icons/quit.png</file>
+        <file>icons/cog.png</file>
+        <file>icons/camera.png</file>
+        <file>icons/camera_grey.png</file>
+        <file>icons/cropping.png</file>
+        <file>icons/database.png</file>
+        <file>icons/home_sc.png</file>
+        <file>icons/workspace_Diffusion.png</file>
+        <file>icons/workspace_Visualization.png</file>
+        <file>icons/workspace_Registration.png</file>
+        <file>icons/workspace_Filtering.png</file>
+        <file>icons/workspace_Segmentation.png</file>
+        <file>icons/folder.png</file>
+        <file>icons/home.png</file>
+        <file>icons/error.png</file>
+        <file>icons/error_add.png</file>
+        <file>icons/error_delete.png</file>
+        <file>icons/error_go.png</file>
+        <file>icons/exclamation.png</file>
+        <file>icons/eye.png</file>
+        <file>icons/help.png</file>
+        <file>icons/help.svg</file>
+        <file>icons/information.png</file>
+        <file>icons/layer.png</file>
+        <file>icons/length.png</file>
+        <file>icons/lightbulb.png</file>
+        <file>icons/lightbulb_add.png</file>
+        <file>icons/lightbulb_delete.png</file>
+        <file>icons/lightbulb_off.png</file>
+        <file>icons/lightning.png</file>
+        <file>icons/lightning_add.png</file>
+        <file>icons/lightning_delete.png</file>
+        <file>icons/lightning_go.png</file>
+        <file>icons/link.png</file>
+        <file>icons/link_add.png</file>
+        <file>icons/link_break.png</file>
+        <file>icons/link_delete.png</file>
+        <file>icons/link_edit.png</file>
+        <file>icons/link_error.png</file>
+        <file>icons/link_go.png</file>
+        <file>icons/link_wl.png</file>
+        <file>icons/lock.png</file>
+        <file>icons/lock_add.png</file>
+        <file>icons/lock_break.png</file>
+        <file>icons/lock_delete.png</file>
+        <file>icons/lock_edit.png</file>
+        <file>icons/lock_go.png</file>
+        <file>icons/lock_open.png</file>
+        <file>icons/magnify.png</file>
+        <file>icons/magifier_zoom_out.png</file>
+        <file>icons/magnifier.png</file>
+        <file>icons/magnifier_zoom_in.png</file>
+        <file>icons/medCustomViewContainerA.png</file>
+        <file>icons/medCustomViewContainerB.png</file>
+        <file>icons/medCustomViewContainerC.png</file>
+        <file>icons/medCustomViewContainerD.png</file>
+        <file>icons/medCustomViewContainerE.png</file>
+        <file>icons/medCustomViewContainerF.png</file>
+        <file>icons/mouse.png</file>
+        <file>icons/mouse_add.png</file>
+        <file>icons/mouse_delete.png</file>
+        <file>icons/mouse_error.png</file>
+        <file>icons/page_add.png</file>
+        <file>icons/page_edit.png</file>
+        <file>icons/page_white_copy.png</file>
+        <file>icons/page_white_database.png</file>
+        <file>icons/page_white_delete.png</file>
+        <file>icons/page_white_dvd.png</file>
+        <file>icons/page_white_error.png</file>
+        <file>icons/page_white_gear.png</file>
+        <file>icons/page_white_get.png</file>
+        <file>icons/page_white_go.png</file>
+        <file>icons/page_white_key.png</file>
+        <file>icons/page_white_lightning.png</file>
+        <file>icons/page_white_link.png</file>
+        <file>icons/page_white_magnify.png</file>
+        <file>icons/page_white_put.png</file>
+        <file>icons/page_white_stack.png</file>
+        <file>icons/settings.svg</file>
+        <file>icons/stack.png</file>
+        <file>icons/widget.png</file>
+        <file>icons/wlww.png</file>
+        <file>icons/zoom.png</file>
+        <file>icons/zoom_in.png</file>
+        <file>icons/zoom_out.png</file>
+        <file>icons/backward.png</file>
+        <file>icons/forward.png</file>
+        <file>icons/star.svg</file>
+        <file>icons/user_add.png</file>
+        <file>icons/user_edit.png</file>
+        <file>medInria.qss</file>
+        <file>pixmaps/unknown.jpg</file>
+        <file>pixmaps/checkbox.png</file>
+        <file>pixmaps/checkbox-checked.png</file>
+        <file>pixmaps/checkbox-partial.png</file>
+        <file>pixmaps/radio.png</file>
+        <file>pixmaps/radio-checked.png</file>
+        <file>pixmaps/radio-partial.png</file>
+        <file>pixmaps/drop-down.png</file>
+        <file>pixmaps/treeview-branch-closed.png</file>
+        <file>pixmaps/treeview-branch-open.png</file>
+        <file>pixmaps/database_navigator_item_checker_checked.png</file>
+        <file>pixmaps/database_navigator_item_checker_unchecked.png</file>
+        <file>pixmaps/medInria-logo-homepage.png</file>
+        <file>pixmaps/medInria-splash.png</file>
+        <file>pixmaps/delete.png</file>
+        <file>icons/settings.png</file>
+        <file>icons/stop.png</file>
+        <file>icons/pause.png</file>
+        <file>icons/play.png</file>
+        <file>authors.html</file>
+        <file>icons/fullscreenExpand.png</file>
+        <file>icons/fullscreenReduce.png</file>
+        <file>icons/medInriaPlugin.png</file>
+        <file>icons/import.png</file>
+        <file>icons/export.png</file>
+        <file>icons/load.svg</file>
+        <file>icons/export.svg</file>
+        <file>icons/save.svg</file>
+        <file>icons/save.png</file>
+        <file>icons/magnifier.svg</file>
+        <file>icons/cross.svg</file>
+        <file>icons/finger.png</file>
+        <file>icons/document-open.png</file>
+        <file>icons/maximize.svg</file>
+        <file>icons/whitecross.svg</file>
+        <file>icons/link.svg</file>
+        <file>icons/broken_link.svg</file>
+        <file>icons/un_maximize.svg</file>
+        <file>pixmaps/radio-disabled.png</file>
+        <file>pixmaps/radio-checked-disabled.png</file>
+        <file>pixmaps/plus-button.png</file>
+        <file>pixmaps/checkbox-disabled.png</file>
+        <file>pixmaps/checkbox-checked-disabled.png</file>
+        <file>pixmaps/arrow-top-disabled.png</file>
+        <file>pixmaps/arrow-top.png</file>
+        <file>pixmaps/arrow-right-disabled.png</file>
+        <file>pixmaps/arrow-right.png</file>
+        <file>pixmaps/arrow-left-disabled.png</file>
+        <file>pixmaps/arrow-left.png</file>
+        <file>pixmaps/arrow-bot-disabled.png</file>
+        <file>pixmaps/arrow-bot.png</file>
+        <file>icons/adjust_size.png</file>
+    </qresource>
 </RCC>

--- a/app/medInria/resources/medInria.qss
+++ b/app/medInria/resources/medInria.qss
@@ -18,18 +18,6 @@
 $HUE        = 228;
 $SATURATION = 255;
 
-/*$GREY00     = hsv($HUE,$SATURATION,25);
-$GREY01     = hsv($HUE,$SATURATION,48);
-$GREY02     = hsv($HUE,$SATURATION,56);
-$GREY03     = hsv($HUE,$SATURATION,60);
-$GREY04     = hsv($HUE,$SATURATION,64);
-$GREY05     = hsv($HUE,$SATURATION,80);
-$GREY06     = hsv($HUE,$SATURATION,96);
-$GREY07     = hsv($HUE,$SATURATION,112);
-$GREY08     = hsv($HUE,$SATURATION,128);
-$GREY09     = hsv($HUE,$SATURATION,144);
-$GREY10     = hsv($HUE,$SATURATION,160);*/
-
 $GREY10     = hsv($HUE,$SATURATION,0);
 $GREY09     = hsv($HUE,$SATURATION,10);
 $GREY08     = hsv($HUE,$SATURATION,20);
@@ -42,14 +30,13 @@ $GREY02     = hsv($HUE,$SATURATION,80);
 $GREY01     = hsv($HUE,$SATURATION,90);
 $GREY00     = hsv($HUE,$SATURATION,120);
 
-$GREY11     = #C0C0C0;/*hsv($HUE,$SATURATION,192);*/
-
+$GREY11     = #C0C0C0;
 $GREEN      = #64FF32;
 $RED        = #FF3333;
 $YELLOW     = #FFFF99;
 $DARKGRAY   = #6D6E6F;
-
-$HIGHLIGHT_COLOR = #FF8833;
+$HIGHLIGHT_COLOR = #FF8833; /*orange*/
+$MEDINRIA_DARKGRAY = #2b2b2d;
 
 /*******************************************************************************
     BACKGROUND
@@ -96,8 +83,8 @@ $SCROLL_BAR_VERTICAL_BACKGROUND         = $GREY04;
 $HOME_PAGE_BUTTON_BACKGROUND            = $GREY03;
 $HOME_PAGE_BUTTON_HOVER_BACKGROUND      = $GREY00;
 
-$TOOLBOX_CONTAINER_BACKGROUND           = $GREY01;
-$TOOLBOX_HEADER_BACKGROUND              = qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $GREY05, stop: 0.3 $GREY00, stop: 1 $GREY05);
+$TOOLBOX_CONTAINER_BACKGROUND           = $GREY01; /*does not seem to be visible*/
+$TOOLBOX_HEADER_BACKGROUND              = qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $DARKGRAY, stop: 1 $MEDINRIA_DARKGRAY);
 $TOOLBOX_BODY_BACKGROUND                = qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $GREY02, stop: 1 $GREY01);
 $TOOLBOX_BACKGROUND                     = $GREY05;
 

--- a/src/medCore/gui/medAbstractWorkspace.cpp
+++ b/src/medCore/gui/medAbstractWorkspace.cpp
@@ -332,7 +332,7 @@ void medAbstractWorkspace::updateLayersToolBox()
                 QFontMetrics fm(myFont);
                 //TODO: could be nice to elide according to current width (update when resize)
                 QString text = fm.elidedText(name, Qt::ElideRight, 100);
-                QLabel *layerName = new QLabel("<font color='Black'>"+text+"</font>", layerWidget);
+                QLabel *layerName = new QLabel("<font color='darkorange'>"+text+"</font>", layerWidget);
                 layerName->setToolTip(name);
 
                 layout->addWidget(thumbnailButton);
@@ -459,7 +459,7 @@ void medAbstractWorkspace::updateInteractorsToolBox()
     QList<QString> interactorsIdentifier;
     QUuid containerUuid = d->containerForLayerWidgetsItem.value(item);
     medViewContainer *container = containerMng->container(containerUuid);
-    container->highlight("#FF8844");
+    container->highlight("#FF8844"); //container contour color
 
     medAbstractLayeredView *view = dynamic_cast<medAbstractLayeredView*>(container->view());
 


### PR DESCRIPTION
:japanese_goblin: 

/!\ Sorry for the .qrc file indentation. I did not do anything, but I tested something and qtcreator automatically did that :calimero: /!\

1) app/medInria/resources/medInria.qss
Change the header of toolboxes into a gray gradient. Before crying, use these toolboxes few minutes in order to be used to the change :)

2) src/medCore/gui/medAbstractWorkspace.cpp
Change the color of the layer text in Layer Settings. I tried a lot of colors, but the orange one is the best I think. Orange is already used in MUSIC, and it's visible.

:japanese_ogre: 

![grayandorangetxt](https://cloud.githubusercontent.com/assets/3910352/7317916/a8c9e7d0-ea86-11e4-8ac9-bfbdde204c17.png)
