### PR TITLE
[algoPaintTlbx] adapt magic wand to pipeline

### DIFF
--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.cpp
@@ -471,6 +471,7 @@ AlgorithmPaintToolbox::AlgorithmPaintToolbox(QWidget *parent ) :
     connect(reduceBrushSize_shortcut,SIGNAL(activated()),this,SLOT(reduceBrushSize()));
 
     maskHasBeenSaved = false;
+    isCustomedCursor = false;
 }
 
 AlgorithmPaintToolbox::~AlgorithmPaintToolbox()
@@ -593,12 +594,17 @@ void AlgorithmPaintToolbox::activateCustomedCursor()
     // Update the cursor
     QApplication::setOverrideCursor(QCursor(pix, -1, -1));
     QApplication::processEvents();
+    isCustomedCursor = true;
 }
 
 void AlgorithmPaintToolbox::deactivateCustomedCursor()
 {
-    QApplication::setOverrideCursor(Qt::ArrowCursor);
-    QApplication::processEvents();
+    if (isCustomedCursor)
+    {
+        QApplication::setOverrideCursor(Qt::ArrowCursor);
+        QApplication::processEvents();
+        isCustomedCursor = false;
+    }
 }
 
 void AlgorithmPaintToolbox::activateMagicWand()

--- a/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
+++ b/src-plugins/medSegmentation/msegAlgorithmPaintToolbox.h
@@ -205,6 +205,7 @@ private:
     QLabel *m_colorLabel;
     QShortcut *undo_shortcut, *redo_shortcut, *copy_shortcut, *paste_shortcut;
     unsigned int m_strokeLabel;
+    bool isCustomedCursor;
     //
 
     double m_MinValueImage;


### PR DESCRIPTION
:taxi: 

Magic Wand automatically clicked in pipeline does not put a wrong default cursor anymore.

:taxi: 
