### PR TITLE
Fix broken camera rotation

### DIFF
--- a/src/medVtkInria/vtkWidgetsAddOn/vtkInteractorStyleTrackballCamera2.cxx
+++ b/src/medVtkInria/vtkWidgetsAddOn/vtkInteractorStyleTrackballCamera2.cxx
@@ -107,13 +107,17 @@ void vtkInteractorStyleTrackballCamera2::Azimuth(double angle)
 {
   vtkCamera *camera = this->CurrentRenderer->GetActiveCamera();
 
+  double axis[3];
   double newPosition[3];
   double fp[3]; camera->GetFocalPoint(fp);
   double position[3]; camera->GetPosition(position);
 
+  // We need to source the vertical axis each time, as the camera can rotate
+  camera->GetViewUp(axis);
+
   this->Transform->Identity();
   this->Transform->Translate(+fp[0],+fp[1],+fp[2]);
-  this->Transform->RotateWXYZ(angle, UpAxis);
+  this->Transform->RotateWXYZ(angle, axis);
   this->Transform->Translate(-fp[0],-fp[1],-fp[2]);
   this->Transform->TransformPoint(position, newPosition);
 


### PR DESCRIPTION
When rotating the camera round the x-axis, we correctly set the camera y-axis. Unfortunately, when rotating around the z-axis, this code is handled by vtk directly rather than our own code.

This means that the camera's actual y-axis was not being stored, which meant that rotating around the y-axis (when rotating in the horizontal plane) was not working correctly, as we were using outdated y-axis information.

The new code now gets the y-axis 'live', rather than relying on a stored variable.