### PR TITLE
extraNavigators back to protected

### DIFF
--- a/src/medCore/views/medAbstractView.h
+++ b/src/medCore/views/medAbstractView.h
@@ -61,7 +61,6 @@ public:
     virtual QWidget* toolBarWidget();
 
     virtual QList<medAbstractNavigator*> navigators();
-    virtual QList<medAbstractNavigator*> extraNavigators();
     virtual QList<medAbstractInteractor*> interactors();
 
     medDoubleParameter* zoomParameter();
@@ -97,6 +96,7 @@ protected:
     virtual medAbstractViewInteractor* primaryInteractor();
     virtual QList<medAbstractInteractor*> extraInteractors();
     virtual medAbstractViewNavigator* primaryNavigator();
+    virtual QList<medAbstractNavigator*> extraNavigators();
 
     virtual bool initialiseInteractors(medAbstractData* data);
     virtual bool initialiseNavigators();


### PR DESCRIPTION
In the plugins we can use `navigators()` instead of `extraNavigators()`, so let's keep this one protected as in medInria-public.