### PR TITLE
[HISTOG] Corrects bug with images with negative values

### DIFF
--- a/src-plugins/itkDataImage/datas/itkDataPrivateTypes.h
+++ b/src-plugins/itkDataImage/datas/itkDataPrivateTypes.h
@@ -74,9 +74,7 @@ public:
 
     int scalarValueCount(int value) {
         computeValueCounts();
-        if((PixelType)value>=range_min && (PixelType)value<=range_max)
-            return histogram->GetFrequency(value,0);
-        return -1;
+        return histogram->GetFrequency((PixelType)value);
     }
 
     int scalarValueMinCount() {


### PR DESCRIPTION
With current code, no histogram is displayed if the image contains negative values.