### PR TITLE
When loading a scene, set the right windowing

### DIFF
--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -344,6 +344,15 @@ QString vtkDataMeshInteractor::renderingType() const
     return QString::fromStdString(d->actorProperty->GetRepresentationAsString()).toLower();
 }
 
+void vtkDataMeshInteractor::setMaxRange(double max)
+{
+    d->maxRange->setValue(max);
+}
+
+void vtkDataMeshInteractor::setMinRange(double min)
+{
+    d->minRange->setValue(min);
+}
 
 void vtkDataMeshInteractor::setAttribute(const QString & attributeName)
 {
@@ -695,6 +704,10 @@ void vtkDataMeshInteractor::restoreParameters(QHash<QString, QString> parameters
         setRenderingType(parameters["Rendering"]);
     if(parameters.contains("Color"))
         setColor(parameters["Color"]);
+    if(parameters.contains("Max"))
+        setMaxRange(medDoubleParameter::fromString(parameters["Max"]));
+    if(parameters.contains("Min"))
+        setMinRange(medDoubleParameter::fromString(parameters["Min"]));
 }
 
 QString vtkDataMeshInteractor::name() const

--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.h
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.h
@@ -60,6 +60,8 @@ public slots:
     void setWindowLevel (QHash<QString,QVariant>);
     void setColor(const QString &color);
     void setColor(QColor color);
+    void setMaxRange(double max);
+    void setMinRange(double min);
     void setVisibility(bool visible);
     void setEdgeVisibility(bool visible);
     void setRenderingType(const QString &type);


### PR DESCRIPTION
When saving the scene, we save all the rendering parameters, but forget to use the windowing ones when opening the scene.