### PR TITLE
Prevents from writing on the disk when saving DATA non-persistently

### DIFF
--- a/src/medCore/database/medAbstractDatabaseImporter.cpp
+++ b/src/medCore/database/medAbstractDatabaseImporter.cpp
@@ -56,12 +56,12 @@ medAbstractDatabaseImporter::medAbstractDatabaseImporter ( const QString& file, 
 
 //-----------------------------------------------------------------------------------------------------------
 
-medAbstractDatabaseImporter::medAbstractDatabaseImporter ( medAbstractData* medData, const QUuid& uuid) : medJobItem(), d ( new medAbstractDatabaseImporterPrivate )
+medAbstractDatabaseImporter::medAbstractDatabaseImporter ( medAbstractData* medData, const QUuid& uuid, bool indexWithoutImporting) : medJobItem(), d ( new medAbstractDatabaseImporterPrivate )
 {
     d->isCancelled = false;
     d->data = medData;
     d->file = QString("");
-    d->indexWithoutImporting = false;
+    d->indexWithoutImporting = indexWithoutImporting;
     d->uuid = uuid;
 }
 

--- a/src/medCore/database/medAbstractDatabaseImporter.h
+++ b/src/medCore/database/medAbstractDatabaseImporter.h
@@ -44,7 +44,7 @@ class MEDCORE_EXPORT medAbstractDatabaseImporter : public medJobItem
 
 public:
     medAbstractDatabaseImporter (const QString& file, const QUuid &uuid, bool indexWithoutImporting = false);
-    medAbstractDatabaseImporter ( medAbstractData* medData, const QUuid& uuid);
+    medAbstractDatabaseImporter ( medAbstractData* medData, const QUuid& uuid, bool indexWithoutImporting = false);
 
     ~medAbstractDatabaseImporter ( void );
 

--- a/src/medCore/database/medDatabaseNonPersistentImporter.cpp
+++ b/src/medCore/database/medDatabaseNonPersistentImporter.cpp
@@ -38,7 +38,7 @@ medDatabaseNonPersistentImporter::medDatabaseNonPersistentImporter (const QStrin
 //-----------------------------------------------------------------------------------------------------------
 
 medDatabaseNonPersistentImporter::medDatabaseNonPersistentImporter (medAbstractData* medData, const QUuid &uuid )
-: medAbstractDatabaseImporter(medData, uuid)
+: medAbstractDatabaseImporter(medData, uuid, true)
 {
     qDebug() << "medDatabaseNonPersistentImporter created with uuid:" << this->callerUuid();
 }


### PR DESCRIPTION
When saving non-persistently a **data**, it was actually writing the file on the db.
When saving non-persistently a **file**, it works fine.

This difference in behavior is due to two ```medAbstractDatabaseImporter``` constructors, one taking care of setting the boolean ```indexWithoutImporting```, the other setting it to false.
And it's this boolean that tells whether you want to write the data on the disk or not.

To see if this PR works, just check the size (and number of files in your db) before and after any operation that creates a non-persistent data. These numbers shouldn't change.