### PR TITLE
[shrinkFilter] shrink factors > 0 (very simple PR)

### DIFF
--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -182,14 +182,17 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medFilteringAbstractT
     d->shrinkFilterWidget = new QWidget;
     d->shrink0Value = new QSpinBox;
     d->shrink0Value->setValue ( 1 );
+    d->shrink0Value->setMinimum ( 1 );
     d->shrink0Value->setMaximum ( 10 );
 
     d->shrink1Value = new QSpinBox;
     d->shrink1Value->setValue ( 1 );
+    d->shrink1Value->setMinimum ( 1 );
     d->shrink1Value->setMaximum ( 10 );
 
     d->shrink2Value = new QSpinBox;
     d->shrink2Value->setValue ( 1 );
+    d->shrink2Value->setMinimum ( 1 );
     d->shrink2Value->setMaximum ( 10 );
 
     QLabel * shrinkFilterLabel = new QLabel ( tr ( "Shrink factors (X,Y,Z):" ) );


### PR DESCRIPTION
Probably corrects the crash Mathilde reported a previous email.
Small part of the crash log:
*terminating with uncaught exception of type itk::ExceptionObject: /Users/buildbot/dev/MUSIC/medinria-superproject/ITK/Modules/Core/Common/include/itkImageBase.hxx:191:
itk::ERROR: Image(0x1287be6d0): A spacing of 0 is not allowed: Spacing is [3.69141, 2.21484, 0]*

From my understanding, it means that the user sets the third shrink factor to 0, which is not handled by the filter.
Concerning shrink factors, ITK says:
"*Values are clamped to a minimum value of 1. Default is 1 for all dimensions.*"