### PR TITLE
Improving scene saving 

### DIFF
--- a/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -714,14 +714,14 @@ void medVtkViewItkDataImageInteractor::enableWIndowLevel(bool enable)
 
 void medVtkViewItkDataImageInteractor::restoreParameters(QHash<QString,QString> parameters)
 {
-	if(parameters.contains("Opacity"))
-		setOpacity(medDoubleParameter::fromString(parameters["Opacity"]));
-	if(parameters.contains("Visibility"))
-		setVisibility(medBoolParameter::fromString(parameters["Visibility"]));
-	if(parameters.contains("Preset"))
-		setPreset(medStringListParameter::fromString(parameters["Preset"]));
+    if(parameters.contains("Opacity"))
+        setOpacity(medDoubleParameter::fromString(parameters["Opacity"]));
+    if(parameters.contains("Visibility"))
+        setVisibility(medBoolParameter::fromString(parameters["Visibility"]));
+    if(parameters.contains("Preset"))
+        setPreset(medStringListParameter::fromString(parameters["Preset"]));
     if(parameters.contains("Lut"))
-		setLut(medStringListParameter::fromString(parameters["Lut"]));
+        setLut(medStringListParameter::fromString(parameters["Lut"]));
     if(parameters.contains("Max Intensity"))
         setMaxIntensity(medDoubleParameter::fromString(parameters["Max Intensity"]));
     if(parameters.contains("Min Intensity"))

--- a/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -467,6 +467,15 @@ QString medVtkViewItkDataImageInteractor::preset() const
   return d->presetParam->value();
 }
 
+void medVtkViewItkDataImageInteractor::setMinIntensity(double min)
+{
+    d->minIntensityParameter->setValue(min);
+}
+
+void medVtkViewItkDataImageInteractor::setMaxIntensity(double max)
+{
+    d->maxIntensityParameter->setValue(max);
+}
 
 QWidget* medVtkViewItkDataImageInteractor::buildToolBarWidget()
 {
@@ -713,6 +722,10 @@ void medVtkViewItkDataImageInteractor::restoreParameters(QHash<QString,QString> 
 		setPreset(medStringListParameter::fromString(parameters["Preset"]));
     if(parameters.contains("Lut"))
 		setLut(medStringListParameter::fromString(parameters["Lut"]));
+    if(parameters.contains("Max Intensity"))
+        setMaxIntensity(medDoubleParameter::fromString(parameters["Max Intensity"]));
+    if(parameters.contains("Min Intensity"))
+        setMinIntensity(medDoubleParameter::fromString(parameters["Min Intensity"]));
 }
 
 QString medVtkViewItkDataImageInteractor::name() const

--- a/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.h
+++ b/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.h
@@ -53,7 +53,6 @@ public slots:
     virtual void setLut(QString lut);
     void setWindowLevel(QHash<QString, QVariant>);
     void enableWIndowLevel(bool enable);
-
     void setVisibility(bool);
 
     virtual void removeData();
@@ -72,6 +71,9 @@ private:
 
     template <typename IMAGE>
     bool SetViewInput(const char* type, medAbstractData* data, int layer);
+
+    void setMaxIntensity(double max);
+    void setMinIntensity(double min);
 
 private slots:
     void updateSlicingParam();

--- a/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.cpp
+++ b/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.cpp
@@ -47,6 +47,11 @@ QStringList itkMetaDataImageWriter::handled() const {
     return s_handled();
 }
 
+QStringList itkMetaDataImageWriter::supportedFileExtensions() const
+{
+    return QStringList() << ".mhd";
+}
+
 bool itkMetaDataImageWriter::registered() {
     return medAbstractDataFactory::instance()->registerDataWriterType(s_identifier(), s_handled(), create);
 }

--- a/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.h
+++ b/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.h
@@ -24,6 +24,7 @@ public:
     virtual QString identifier()  const;
     virtual QString description() const;
     virtual QStringList handled() const;
+    virtual QStringList supportedFileExtensions() const;
 
     static bool registered();
 

--- a/src/medCore/views/medAbstractLayeredView.cpp
+++ b/src/medCore/views/medAbstractLayeredView.cpp
@@ -471,13 +471,14 @@ void medAbstractLayeredView::write(QString& path)
         // we use allWriters as the list of keys to make sure we traverse possibleWriters
         // in the order specified by the writers priorities.
         foreach(QString type, allWriters) {
-            if (!possibleWriters.contains(type))
-                continue;
-            QStringList extensionList = possibleWriters[type]->supportedFileExtensions();
-            if(!extensionList.isEmpty())
+            if (possibleWriters.contains(type))
             {
-                fileExtension = extensionList.first();
-                break;
+                QStringList extensionList = possibleWriters[type]->supportedFileExtensions();
+                if(!extensionList.isEmpty())
+                {
+                    fileExtension = extensionList.first();
+                    break;
+                }
             }
         }
         //3.releasing allocated memory

--- a/src/medCore/views/medAbstractLayeredView.cpp
+++ b/src/medCore/views/medAbstractLayeredView.cpp
@@ -463,16 +463,18 @@ void medAbstractLayeredView::write(QString& path)
 
         //getting a working file extension
         //1. find suitable writers
+        QList<QString> allWriters = medAbstractDataFactory::instance()->writers();
         QHash<QString, dtkAbstractDataWriter*> possibleWriters=medDataManager::instance()->getPossibleWriters(layerData(i));
-
 
         //2. use these writers to get a suitable file extension
         QString fileExtension;
-        foreach(QString key,possibleWriters.keys())
-        {
-            if(!possibleWriters[key]->supportedFileExtensions().isEmpty())
+        // we use allWriters as the list of keys to make sure we traverse possibleWriters
+        // in the order specified by the writers priorities.
+        foreach(QString type, allWriters) {
+            QStringList extensionList = possibleWriters[type]->supportedFileExtensions();
+            if(!extensionList.isEmpty())
             {
-                fileExtension=possibleWriters[key]->supportedFileExtensions()[0];
+                fileExtension = extensionList.first();
                 break;
             }
         }

--- a/src/medCore/views/medAbstractLayeredView.cpp
+++ b/src/medCore/views/medAbstractLayeredView.cpp
@@ -471,6 +471,8 @@ void medAbstractLayeredView::write(QString& path)
         // we use allWriters as the list of keys to make sure we traverse possibleWriters
         // in the order specified by the writers priorities.
         foreach(QString type, allWriters) {
+            if (!possibleWriters.contains(type))
+                continue;
             QStringList extensionList = possibleWriters[type]->supportedFileExtensions();
             if(!extensionList.isEmpty())
             {


### PR DESCRIPTION
Scene saving was mostly tested with meshes.
As reported in https://github.com/Inria-Asclepios/music/issues/210, there were some issues with the volumes.
* Part of it was that the extension (.mhd, .gipl, etc) of the volume in the xml didn't match the real one. This was because, when naming a file in the xml, we didn't go through the possible writers the same way we do when writing (saving) the data.
To make it clear, i did the test with the classic I1.mhd; its name was I1.gipl in the xml.

* Correcting that, I also noticed that the a method was missing in ```itkMetaDataImageWriter```(the one handling .mhd files).

* Finally the windowing was saved but not applied when opening scenes with volumes.

Tests are more than needed to approve/disapprove this PR, so please do some (with meshes and volumes).

Note: a container has to be selected (highlighted in orange) for the scene opening to work.