### PR TITLE
medComboBox, QComboBox without scrolling mess

### DIFF
--- a/app/medInria/medRegistrationWorkspace.cpp
+++ b/app/medInria/medRegistrationWorkspace.cpp
@@ -48,6 +48,7 @@ medRegistrationWorkspace::medRegistrationWorkspace(QWidget *parent) : medAbstrac
     // -- Registration toolbox --
 
     d->registrationToolBox = new medRegistrationSelectorToolBox(parent);
+    d->registrationToolBox->setWorkspace(this);
     this->addToolBox(d->registrationToolBox);
 
     d->viewGroup = new medViewParameterGroup("View Group 1", this, this->identifier());

--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -49,7 +49,7 @@ class iterativeClosestPointToolBoxPrivate
 public:
     
     medAbstractLayeredView * currentView;
-    QComboBox * layerSource, * layerTarget;
+    medComboBox * layerSource, * layerTarget;
     QDoubleSpinBox * ScaleFactor,* MaxMeanDistance;
     QSpinBox * MaxNumIterations, * MaxNumLandmarks;
     QCheckBox * bStartByMatchingCentroids,*bRididBody,*bCheckMeanDistance;
@@ -67,14 +67,14 @@ iterativeClosestPointToolBox::iterativeClosestPointToolBox(QWidget *parent) : me
     this->setTitle("Mesh Registration");
       
     // Parameters'widgets
-    d->layerSource = new QComboBox;
+    d->layerSource = new medComboBox;
     d->layerSource->addItem("Select the layer", 0);
     QLabel * layerSource_Label = new QLabel("Layer number for source mesh");
     QHBoxLayout * layerSource_layout = new QHBoxLayout;
     layerSource_layout->addWidget(layerSource_Label);
     layerSource_layout->addWidget(d->layerSource);
     
-    d->layerTarget = new QComboBox;
+    d->layerTarget = new medComboBox;
     d->layerTarget->addItem("Select the layer", 0);
     QLabel * layerTarget_Label = new QLabel("Layer number for target mesh");
     QHBoxLayout * layerTarget_layout = new QHBoxLayout;

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -76,7 +76,7 @@ public:
     QDoubleSpinBox * intensityOutputMinimumValue;
     QDoubleSpinBox * intensityOutputMaximumValue;
 
-    QComboBox * filters;
+    medComboBox * filters;
     dtkSmartPointer <itkFiltersProcessBase> process;
     
     medProgressionStack * progressionStack;
@@ -86,7 +86,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medFilteringAbstractT
 {
     qDebug() << "itkFiltersToolBox";
     //Filters selection combobox
-    d->filters = new QComboBox(this);
+    d->filters = new medComboBox(this);
     d->filters->setObjectName("Add Constant to Image");
     QStringList filtersList;
     filtersList << "Add Constant to Image" 

--- a/src-plugins/itkFilters/itkMorphologicalFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersToolBox.cpp
@@ -48,7 +48,7 @@ public:
     QSpinBox * kernelSize;
     QRadioButton *mmButton, *pixelButton;
     
-    QComboBox * filters;
+    medComboBox * filters;
     dtkSmartPointer <itkMorphologicalFiltersProcessBase> process;
     
     medProgressionStack * progressionStack;
@@ -57,7 +57,7 @@ public:
 itkMorphologicalFiltersToolBox::itkMorphologicalFiltersToolBox ( QWidget *parent ) : medFilteringAbstractToolBox ( parent ), d ( new itkMorphologicalFiltersToolBoxPrivate )
 {
     //Filters selection combobox
-    d->filters = new QComboBox;
+    d->filters = new medComboBox;
     d->filters->setObjectName("Dilate");
     QStringList filtersList;
     filtersList << "Dilate "

--- a/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
+++ b/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
@@ -40,8 +40,8 @@ class itkProcessRegistrationDiffeomorphicDemonsToolBoxPrivate
 public:
 
     medProgressionStack * progressionStack;
-    QComboBox * updateRuleBox;
-    QComboBox * gradientTypeBox;
+    medComboBox * updateRuleBox;
+    medComboBox * gradientTypeBox;
     QDoubleSpinBox * maxStepLengthBox;
     QDoubleSpinBox * disFieldStdDevBox;
     QDoubleSpinBox * updateFieldStdDevBox;
@@ -91,7 +91,7 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
                 "Standard deviation of the Gaussian smoothing of "
                 "the displacement field (voxel units). Setting it below 0.1 "
                 "means no smoothing will be performed (default 1.5)."));
-    d->updateRuleBox = new QComboBox(this);
+    d->updateRuleBox = new medComboBox(this);
     QStringList updateRules;
     updateRules<< tr("Diffeomorphic") << tr ("Additive") << tr("Compositive");
     d->updateRuleBox->addItems(updateRules);
@@ -100,7 +100,7 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
     d->updateRuleBox->setItemData(1,"s <- s + u",Qt::ToolTipRole);
     d->updateRuleBox->setItemData(2,"s <- s o (Id+u)",Qt::ToolTipRole);
 
-    d->gradientTypeBox = new QComboBox(this);
+    d->gradientTypeBox = new medComboBox(this);
     d->gradientTypeBox->setToolTip(tr(
                 "Type of gradient used for computing the demons force."));
     QStringList gradientTypes;

--- a/src-plugins/medClut/medClutToolBox.cpp
+++ b/src-plugins/medClut/medClutToolBox.cpp
@@ -50,8 +50,8 @@ public:
     medDoubleSliderSpinboxPair * minRange;
     medDoubleSliderSpinboxPair * maxRange;
     QStringList listOfAttributes;
-    QComboBox * attributeBox;
-    QComboBox * lutBox;
+    medComboBox * attributeBox;
+    medComboBox * lutBox;
     QStringList luts;
     QHash<medAbstractView*,vtkLookupTable*>* viewAndLut;
     QHash<medAbstractView*,int> * attributeChosen;
@@ -70,14 +70,14 @@ medToolBox(parent), d(new medClutToolBoxPrivate)
     
     QHBoxLayout * layoutAttribute = new QHBoxLayout();
     QLabel * labelAttribute = new QLabel("Attributes : ");
-    d->attributeBox = new QComboBox(this);
+    d->attributeBox = new medComboBox(this);
     d->attributeBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(d->attributeBox, SIGNAL(activated (int)), this, SLOT(changeAttribute(int)));
 
 
     //QHBoxLayout * layoutLut = new QHBoxLayout();
     //QLabel * labelLut = new QLabel("Lut : ");
-    d->lutBox = new QComboBox(this);
+    d->lutBox = new medComboBox(this);
     d->lutBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(d->lutBox, SIGNAL(activated (int)), this, SLOT(changeLut(int)));
     // get all luts

--- a/src-plugins/reformat/reformatToolBox.cpp
+++ b/src-plugins/reformat/reformatToolBox.cpp
@@ -24,7 +24,7 @@ class reformatToolBoxPrivate
 {
 public:
     QPushButton *b_startReformat, *b_stopReformat, *b_saveImage, *b_reset;
-    QComboBox *bySpacingOrDimension;
+    medComboBox *bySpacingOrDimension;
     QLabel *spacingXLab, *spacingYLab, *spacingZLab, *help0;
     QDoubleSpinBox *spacingX, *spacingY, *spacingZ;
     medAbstractLayeredView * currentView;
@@ -55,7 +55,7 @@ reformatToolBox::reformatToolBox (QWidget *parent) : medSegmentationAbstractTool
     // User can choose pixel or millimeter resample
     QHBoxLayout * resampleLayout = new QHBoxLayout();
     QLabel* bySpacingOrDimensionLabel = new QLabel("Select your resample parameter:", reformatToolBoxBody);
-    d->bySpacingOrDimension = new QComboBox(reformatToolBoxBody);
+    d->bySpacingOrDimension = new medComboBox(reformatToolBoxBody);
     d->bySpacingOrDimension->setObjectName("bySpacingOrDimension");
     d->bySpacingOrDimension->addItem("Spacing");
     d->bySpacingOrDimension->addItem("Dimension");

--- a/src/medCore/gui/commonWidgets/medComboBox.h
+++ b/src/medCore/gui/commonWidgets/medComboBox.h
@@ -1,0 +1,35 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2014. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <QtGui>
+#include <medCoreExport.h>
+
+class MEDCORE_EXPORT medComboBox: public QComboBox {
+
+    Q_OBJECT
+
+public:
+
+    medComboBox(QWidget* parent=0): QComboBox(parent)
+    {
+        this->setFocusPolicy(Qt::StrongFocus);
+    }
+    
+    void wheelEvent(QWheelEvent *e)
+	{
+    	if(hasFocus())
+        	QComboBox::wheelEvent(e);
+	}
+};

--- a/src/medCore/gui/commonWidgets/medComboBox.h
+++ b/src/medCore/gui/commonWidgets/medComboBox.h
@@ -28,8 +28,10 @@ public:
     }
     
     void wheelEvent(QWheelEvent *e)
-	{
-    	if(hasFocus())
-        	QComboBox::wheelEvent(e);
-	}
+    {
+        if(hasFocus())
+        {
+            QComboBox::wheelEvent(e);
+        }
+    }
 };

--- a/src/medCore/gui/toolboxes/medCompositeDataSetImporterSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medCompositeDataSetImporterSelectorToolBox.cpp
@@ -32,7 +32,7 @@ public:
   QWidget* parent;
   QVBoxLayout* customContainerLayout;
 
-  QComboBox* type;
+  medComboBox* type;
   QPushButton* import;
   QPushButton* reset;
   QPushButton* load;
@@ -108,7 +108,7 @@ void medCompositeDataSetImporterSelectorToolBox::initialize()
     QHBoxLayout * topLayout = new QHBoxLayout();
     topLayout->addStretch(0);
 
-    d->type = new QComboBox(mainwidget);
+    d->type = new medComboBox(mainwidget);
     d->type->addItem(tr("Select data type"));
     d->type->setToolTip(tr("Choose a type of composite data set to import"));
 

--- a/src/medCore/gui/toolboxes/medDiffusionSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medDiffusionSelectorToolBox.cpp
@@ -44,11 +44,11 @@ public:
     QPushButton *runButton;
     QPushButton *cancelButton;
 
-    QComboBox *methodCombo;
+    medComboBox *methodCombo;
     QVBoxLayout *mainLayout;
 
     //QLabel *inputLabel;
-    QComboBox *chooseInput;
+    medComboBox *chooseInput;
     //TODO smartPointing have to be managed only in abstract processes -rde
     QMap <QString, dtkSmartPointer <medAbstractImageData> > inputsMap;
 };
@@ -90,7 +90,7 @@ medDiffusionSelectorToolBox::medDiffusionSelectorToolBox(QWidget *parent, Select
     }
 
     QLabel *methodLabel = new QLabel(labelTitle, mainPage);
-    d->methodCombo = new QComboBox(mainPage);
+    d->methodCombo = new medComboBox(mainPage);
 
     QHBoxLayout *methodLayout = new QHBoxLayout;
     methodLayout->addWidget(methodLabel);
@@ -120,7 +120,7 @@ medDiffusionSelectorToolBox::medDiffusionSelectorToolBox(QWidget *parent, Select
     inputDescriptionLabel->setText(tr("Input image:"));
     inputLayout->addWidget(inputDescriptionLabel);
     
-    d->chooseInput = new QComboBox(mainPage);
+    d->chooseInput = new medComboBox(mainPage);
     d->chooseInput->addItem(tr("Please drop an image"));
 	d->chooseInput->setToolTip(tr("Browse available images for processing"));
     d->chooseInput->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Expanding);

--- a/src/medCore/gui/toolboxes/medFilteringSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medFilteringSelectorToolBox.cpp
@@ -29,7 +29,7 @@ class medFilteringSelectorToolBoxPrivate
 {
 public:
 
-    QComboBox    *chooseFilter;
+    medComboBox    *chooseFilter;
     medAbstractData *inputData;
     QHash<QString, medFilteringAbstractToolBox*> toolBoxes;
     QVBoxLayout *filterLayout;
@@ -42,7 +42,7 @@ medFilteringSelectorToolBox::medFilteringSelectorToolBox ( QWidget *parent ) :
     d ( new medFilteringSelectorToolBoxPrivate )
 {
 
-    d->chooseFilter = new QComboBox;
+    d->chooseFilter = new medComboBox;
     d->chooseFilter->addItem ( tr ( "Choose filter" ) );
 	d->chooseFilter->setToolTip(tr("Browse through the list of available filters"));
 

--- a/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
@@ -45,7 +45,7 @@ class medRegistrationSelectorToolBoxPrivate
 public:
     QPushButton * saveTransButton;
 
-    QComboBox *toolboxes;
+    medComboBox *toolboxes;
 
     QVBoxLayout *toolBoxLayout;
 
@@ -81,7 +81,7 @@ medRegistrationSelectorToolBox::medRegistrationSelectorToolBox(QWidget *parent) 
 
     // --- Setting up custom toolboxes list ---
 
-    d->toolboxes = new QComboBox(this);
+    d->toolboxes = new medComboBox(this);
     d->toolboxes->addItem(tr("Choose algorithm"));
     d->toolboxes->setToolTip(
                 tr( "Choose the registration algorithm"

--- a/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
@@ -192,6 +192,7 @@ void medRegistrationSelectorToolBox::changeCurrentToolBox(int index)
     d->nameOfCurrentAlgorithm = medToolBoxFactory::instance()->toolBoxDetailsFromId(id)->name;
 
     toolbox->setRegistrationToolBox(this);
+    toolbox->setWorkspace(getWorkspace());
     d->currentToolBox = toolbox;
     d->currentToolBox->show();
     d->currentToolBox->header()->hide();

--- a/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
@@ -25,7 +25,7 @@
 class medSegmentationSelectorToolBoxPrivate
 {
 public:
-    QComboBox *chooseSegmentationComboBox;
+    medComboBox *chooseSegmentationComboBox;
     medSegmentationAbstractToolBox * currentSegmentationToolBox;
     QHash<QString, medSegmentationAbstractToolBox*> segmentationToolBoxes;
     QVBoxLayout *mainLayout;
@@ -38,7 +38,7 @@ medSegmentationSelectorToolBox::medSegmentationSelectorToolBox(QWidget *parent) 
     d->currentSegmentationToolBox = NULL;
 
 
-    d->chooseSegmentationComboBox = new QComboBox;
+    d->chooseSegmentationComboBox = new medComboBox;
     //TODO algorithm is not the best IMO - RDE
     d->chooseSegmentationComboBox->addItem("Choose algorithm");
     d->chooseSegmentationComboBox->setToolTip(tr("Browse through the list of available segmentation algorithm"));

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -15,6 +15,7 @@
 
 #include <medCoreExport.h>
 #include <medAbstractWorkspace.h>
+#include <medComboBox.h>
 
 #include <QtGui>
 #include <QDomDocument>

--- a/src/medCore/parameters/medStringListParameter.cpp
+++ b/src/medCore/parameters/medStringListParameter.cpp
@@ -10,14 +10,14 @@
 
 #include <medStringListParameter.h>
 
-#include <QComboBox>
+#include <medComboBox.h>
 #include <QDebug>
 
 
 class medStringListParameterPrivate
 {
 public:
-    QComboBox* comboBox;
+    medComboBox* comboBox;
     QStringList items;
     QHash <QString, QIcon> iconForItem;
 
@@ -84,7 +84,7 @@ QComboBox* medStringListParameter::getComboBox()
 {
     if(!d->comboBox)
     {
-        d->comboBox = new QComboBox;
+        d->comboBox = new medComboBox;
         foreach(QString item, d->items)
             d->comboBox->addItem(d->iconForItem.value(item), item);
 


### PR DESCRIPTION
Here is an annoying bug: 
you have a big toolbox, you scroll down, then you accidentally hover a QComboBox and the wheel event is caught by this comboBox, which messes up the toolbox.

Here is the solution I found on the internet: 
- You first have to prevent the comboBox from having focus on mouse wheel event
```c++
this->setFocusPolicy(Qt::StrongFocus); //the widget accepts focus by both tabbing and clicking
```
- Then you have to accept wheel events only when the widget has focus, this means that you have to subclass QComboBox to reimplement ```QComboBox::wheelEvent()```.

I have included the header of this new class in ```medToolBox.h``` since it will be mostly/only used in toolboxes.

I made the changes in the toolboxes and in medStringListParameter (i.e LUT, Preset parameters). Elsewhere (few occurrences ) it was not really needed.

PRs on the MUSIC and medInria-private plugins are here: https://github.com/medInria/medInria-private/pull/10, https://github.com/Inria-Asclepios/music/pull/214