### PR TITLE
Adapts Manual reg. to registration workspace

### DIFF
--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -55,6 +55,8 @@ public slots:
     void reset();
 
 private:
+    void displayButtons(bool);
+    void constructContainers(medTabbedViewContainers *);
     manualRegistrationToolBoxPrivate *d;
 };
 


### PR DESCRIPTION
Allows to use manual registration outside of a pipeline.

For this, it has two behaviours:
- in the registration workspace: inputs are in the proposed containers, output is shown in the Fuse Tab.
- in a pipeline: the toolbox has to create and manage its own containers.

You know that you are in the reg. workspace when you have a *parentToolBox*.

For now, the robustness of the toolbox in the workspace is quite poor, mainly when you switch between registration algorithms; but it does the job as long as you stay simple.

I hesitated to make this PR as it is far from perfect, but let's call it a beginning, other PRs will be done to improve this; I'd rather not complexify this one to have it merged asap.