### PR TITLE
Modify database directory 

### DIFF
--- a/src/medCore/database/medAbstractDatabaseImporter.cpp
+++ b/src/medCore/database/medAbstractDatabaseImporter.cpp
@@ -129,6 +129,12 @@ QString medAbstractDatabaseImporter::callerUuid()
 **/
 void medAbstractDatabaseImporter::internalRun ( void )
 {
+    if(!QDir(medStorage::dataLocation()).exists())
+    {
+        emit showError ( tr ( "Your database path does not exist" ), 5000 );
+        emit failure(this);
+        return;
+    }
     if(!d->file.isEmpty())
         importFile();
     else if ( d->data )

--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -168,6 +168,12 @@ const QSqlDatabase& medDatabaseController::database(void) const
 
 bool medDatabaseController::createConnection(void)
 {
+    if(!QDir(medStorage::dataLocation()).exists())
+    {
+        qDebug()<<"Database path does not exist: "<<medStorage::dataLocation();
+        return false;
+    }
+
     medStorage::mkpath(medStorage::dataLocation() + "/");
 
     if (this->m_database.databaseName().isEmpty())

--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -547,22 +547,15 @@ void medDatabaseController::createImageTable(void)
 bool medDatabaseController::moveDatabase( QString newLocation)
 {
     // close connection if necessary
-    bool needsRestart = false;
     if (this->isConnected())
     {
         this->closeConnection();
-        needsRestart = true;
     }
-
     // now update the datastorage path and make sure to reconnect
     medStorage::setDataLocation(newLocation);
 
-    // restart if necessary
-    if (needsRestart)
-    {
-        qDebug() << "Restarting connection...";
-        this->createConnection();
-    }
+    qDebug() << "Restarting connection...";
+    this->createConnection();
 
     return true;
 }

--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -544,21 +544,26 @@ bool medDatabaseController::moveDatabase( QString newLocation)
 
     QString oldLocation = medStorage::dataLocation();
 
-    // now copy all the images and thumbnails
-    QStringList sourceList;
-    medStorage::recurseAddDir(QDir(oldLocation), sourceList);
+    // if there's no existing db in the new location
+    if(QDir(newLocation).entryInfoList(QStringList("db")).isEmpty()) 
+    {
+        // now copy all the images and thumbnails
+        QStringList sourceList;
+        medStorage::recurseAddDir(QDir(oldLocation), sourceList);
 
-    // create destination filelist
-    QStringList destList;
-    if (!medStorage::createDestination(sourceList,destList,oldLocation, newLocation))
-    {
-        res = false;
-    }
-    else
-    {
-        // now copy
-        if (!medStorage::copyFiles(sourceList, destList))
+        // create destination filelist
+        QStringList destList;
+
+        if (!medStorage::createDestination(sourceList,destList,oldLocation, newLocation))
+        {
             res = false;
+        }
+        else
+        {
+            // now copy
+            if (!medStorage::copyFiles(sourceList, destList))
+                res = false;
+        }
     }
 
     if (res)
@@ -587,13 +592,6 @@ bool medDatabaseController::moveDatabase( QString newLocation)
             qDebug() << "Restarting connection...";
             this->createConnection();
         }
-
-        // now delete the old archive
-        if(medStorage::removeDir(oldLocation))
-            qDebug() << "deleting old database: success";
-        else
-            qDebug() << "deleting old database: failure";
-
     }
 
     if (res)

--- a/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
+++ b/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
@@ -66,7 +66,7 @@ void medDatabaseSettingsWidget::selectDirectory()
         if (!QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files).isEmpty() && QDir(path).entryInfoList(QStringList("db")).isEmpty())
         {
             QMessageBox::information( this, tr("Database location not valid"),
-                                      tr("The directory selected is not valid:\nEither it doesn't point to an existing medInria database directory \nOR your new directory is not empty. \nPlease choose another one."));
+                                      tr("The directory selected is not valid:\nEither it doesn't point to an existing MUSIC database directory \nOR your new directory is not empty. \nPlease choose another one."));
         }
         else
         {

--- a/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
+++ b/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
@@ -23,7 +23,7 @@ class medDatabaseSettingsWidgetPrivate {
 
 public:
   QLineEdit* dbPath;
-  QPushButton* btChooseDir;
+  QPushButton *selectDirectoryButton;
 };
 
 medDatabaseSettingsWidget::medDatabaseSettingsWidget(QWidget *parent) :
@@ -33,29 +33,31 @@ medDatabaseSettingsWidget::medDatabaseSettingsWidget(QWidget *parent) :
     setTabName("Database");
 
     d->dbPath = new QLineEdit(this);
-    d->btChooseDir = new QPushButton(tr("Select directory..."), this);
+    d->selectDirectoryButton = new QPushButton(tr("Select directory..."), this);
+    d->selectDirectoryButton->setToolTip("Change the database directory or create a new database by selecting an empty directory");
 
     QWidget* databaseLocation = new QWidget(this);
     QHBoxLayout* dbLayout = new QHBoxLayout;
     dbLayout->addWidget(d->dbPath);
-    dbLayout->addWidget(d->btChooseDir);
+    dbLayout->addWidget(d->selectDirectoryButton);
     databaseLocation->setLayout(dbLayout);
 
-    connect(d->btChooseDir, SIGNAL(clicked()), this, SLOT(selectDbDirectory()));
+    connect(d->selectDirectoryButton, SIGNAL(clicked()), this, SLOT(selectDirectory()));
 
     databaseLocation->setContentsMargins(0,-8,0,0);
 
     QFormLayout* formLayout = new QFormLayout(this);
     formLayout->addRow(tr("Database location:"), databaseLocation);
-    formLayout->addRow(new QLabel("* The changes will only be effective after a restart of the software."));
+    formLayout->addRow(new QLabel("* The changes will only be effective after saving and restarting the application."));
 }
 
-void medDatabaseSettingsWidget::selectDbDirectory()
+void medDatabaseSettingsWidget::selectDirectory()
 {
-    QFileDialog dialog(this);
-    dialog.setFileMode(QFileDialog::DirectoryOnly);
+    QFileDialog dialog(this, tr("Select the database directory"));
+    QDir defaultPath = QDir(medStorage::dataLocation());
+    defaultPath.cdUp();
+    dialog.setDirectory(defaultPath);
 
-     QString path;
      if (dialog.exec())
      {
          QString path = dialog.selectedFiles().first();

--- a/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
+++ b/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
@@ -47,6 +47,7 @@ medDatabaseSettingsWidget::medDatabaseSettingsWidget(QWidget *parent) :
 
     QFormLayout* formLayout = new QFormLayout(this);
     formLayout->addRow(tr("Database location:"), databaseLocation);
+    formLayout->addRow(new QLabel("* The changes will only be effective after a restart of the software."));
 }
 
 void medDatabaseSettingsWidget::selectDbDirectory()
@@ -58,9 +59,10 @@ void medDatabaseSettingsWidget::selectDbDirectory()
      if (dialog.exec())
      {
          QString path = dialog.selectedFiles().first();
-         if (!QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files).isEmpty())
+         if (!QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files).isEmpty() && QDir(path).entryInfoList(QStringList("db")).isEmpty())
          {
-             QMessageBox::information( this, tr("Directory not empty"), tr("The archive directory needs to be empty! \nPlease choose another one."));
+             QMessageBox::information( this, tr("Database location not valid"), 
+                 tr("The directory selected is not valid:\nEither it doesn't point to an existing medInria database directory \nOR your new directory is not empty. \nPlease choose another one."));
          }
          else
          {

--- a/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
+++ b/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.cpp
@@ -53,24 +53,26 @@ medDatabaseSettingsWidget::medDatabaseSettingsWidget(QWidget *parent) :
 
 void medDatabaseSettingsWidget::selectDirectory()
 {
-    QFileDialog dialog(this, tr("Select the database directory"));
     QDir defaultPath = QDir(medStorage::dataLocation());
     defaultPath.cdUp();
-    dialog.setDirectory(defaultPath);
 
-     if (dialog.exec())
-     {
-         QString path = dialog.selectedFiles().first();
-         if (!QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files).isEmpty() && QDir(path).entryInfoList(QStringList("db")).isEmpty())
-         {
-             QMessageBox::information( this, tr("Database location not valid"), 
-                 tr("The directory selected is not valid:\nEither it doesn't point to an existing medInria database directory \nOR your new directory is not empty. \nPlease choose another one."));
-         }
-         else
-         {
-             d->dbPath->setText(path);
-         }
-     }
+    QString path = QFileDialog::getExistingDirectory(this, tr("Select the database directory"),
+                                                     QDir(defaultPath).absolutePath(),
+                                                     QFileDialog::ShowDirsOnly
+                                                     | QFileDialog::DontResolveSymlinks);
+
+    if(path != "") //the user hasn't clicked on Cancel
+    {
+        if (!QDir(path).entryInfoList(QDir::NoDotAndDotDot | QDir::Dirs | QDir::Files).isEmpty() && QDir(path).entryInfoList(QStringList("db")).isEmpty())
+        {
+            QMessageBox::information( this, tr("Database location not valid"),
+                                      tr("The directory selected is not valid:\nEither it doesn't point to an existing medInria database directory \nOR your new directory is not empty. \nPlease choose another one."));
+        }
+        else
+        {
+            d->dbPath->setText(path);
+        }
+    }
 }
 
 /**

--- a/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.h
+++ b/src/medCore/gui/settingsWidgets/medDatabaseSettingsWidget.h
@@ -32,7 +32,7 @@ public slots:
     void read();
 
 private slots:
-    void selectDbDirectory();
+    void selectDirectory();
 
 protected:
     bool validate();


### PR DESCRIPTION
Current behaviour : 
when you selected a dir, it was moving the db in this dir: cut and paste.

Now,
when you select a dir:
if this dir is empty, it creates a brand new database.
if this dir is not empty AND has a db file in it, it simply points on this db.
in other cases, the change is not applied.

I also managed the case where the db path does not exist anymore (if it were on an external hard disk that has been ejected) for reading and writing on the db.