### PR TITLE
itkDataImageWriterBase use compression on

### DIFF
--- a/src/medImageIO/itkDataImageWriterBase.cpp
+++ b/src/medImageIO/itkDataImageWriterBase.cpp
@@ -59,6 +59,7 @@ bool itkDataImageWriterBase::write_image(const QString& path,const char* type) {
     }
     typename itk::ImageFileWriter<Image>::Pointer writer = itk::ImageFileWriter <Image>::New();
     writer->SetImageIO (this->io);
+    writer->UseCompressionOn();
     writer->SetFileName(path.toAscii().constData());
     writer->SetInput(image);
     writer->Update();


### PR DESCRIPTION
Enables compression of data.
My results with the different writers impacted (forget about dim format).
I've done the tests on a MR image and on a mask.
![screen shot 2016-01-13 at 10 38 36](https://cloud.githubusercontent.com/assets/3705584/12290692/6378077a-b9e3-11e5-979a-2bf739e941da.png)

Good news is we don't need to change the readers, so the previous versions of MUSIC can read the compressed data.
The compression is lossless.