### PR TITLE
Export of study and patient 

### DIFF
--- a/app/medInria/medDatabaseDataSource.cpp
+++ b/app/medInria/medDatabaseDataSource.cpp
@@ -91,6 +91,7 @@ QWidget* medDatabaseDataSource::mainViewWidget()
             connect(d->actionsToolBox, SIGNAL(editClicked()), d->largeView, SLOT(onEditRequested()));
 
             connect(d->largeView, SIGNAL(patientClicked(const medDataIndex&)), d->actionsToolBox, SLOT(patientSelected(const medDataIndex&)));
+            connect(d->largeView, SIGNAL(studyClicked(const medDataIndex&)), d->actionsToolBox, SLOT(studySelected(const medDataIndex&)));
             connect(d->largeView, SIGNAL(seriesClicked(const medDataIndex&)), d->actionsToolBox, SLOT(seriesSelected(const medDataIndex&)));
             connect(d->largeView, SIGNAL(noPatientOrSeriesSelected()), d->actionsToolBox, SLOT(noPatientOrSeriesSelected()));
         }
@@ -168,6 +169,7 @@ QList<medToolBox*> medDatabaseDataSource::getToolBoxes()
             connect(d->actionsToolBox, SIGNAL(editClicked()), d->largeView, SLOT(onEditRequested()));
 
             connect(d->largeView, SIGNAL(patientClicked(const medDataIndex&)), d->actionsToolBox, SLOT(patientSelected(const medDataIndex&)));
+            connect(d->largeView, SIGNAL(studyClicked(const medDataIndex&)), d->actionsToolBox, SLOT(studySelected(const medDataIndex&)));
             connect(d->largeView, SIGNAL(seriesClicked(const medDataIndex&)), d->actionsToolBox, SLOT(seriesSelected(const medDataIndex&)));
             connect(d->largeView, SIGNAL(noPatientOrSeriesSelected()), d->actionsToolBox, SLOT(noPatientOrSeriesSelected()));
         }

--- a/src/medCore/gui/database/medDatabaseView.cpp
+++ b/src/medCore/gui/database/medDatabaseView.cpp
@@ -229,6 +229,7 @@ void medDatabaseView::updateContextMenu(const QPoint& point)
         {
             d->contextMenu->addAction(d->editAction);
             d->editAction->setIcon(QIcon(":icons/page_edit.png"));
+            d->contextMenu->addAction(d->exportAction);
             d->contextMenu->addAction(d->removeAction);
             if( !(medDataManager::instance()->controllerForDataSource(item->dataIndex().dataSourceId())->isPersistent()) )
                 d->contextMenu->addAction(d->saveAction);
@@ -238,6 +239,7 @@ void medDatabaseView::updateContextMenu(const QPoint& point)
             d->contextMenu->addAction(d->addStudyAction);
             d->contextMenu->addAction(d->editAction);
             d->editAction->setIcon(QIcon(":icons/user_edit.png"));
+            d->contextMenu->addAction(d->exportAction);
             d->contextMenu->addAction(d->removeAction);
             if( !(medDataManager::instance()->controllerForDataSource(item->dataIndex().dataSourceId())->isPersistent()) )
                 d->contextMenu->addAction(d->saveAction);
@@ -282,6 +284,7 @@ void medDatabaseView::onViewSelectedItemRequested(void)
     }
 }
 
+
 /** Exports the currently selected item. */
 void medDatabaseView::onExportSelectedItemRequested(void)
 {
@@ -299,7 +302,30 @@ void medDatabaseView::onExportSelectedItemRequested(void)
         item = static_cast<medAbstractDatabaseItem *>(proxy->mapToSource(index).internalPointer());
 
     if(item)
-        emit exportData(item->dataIndex());
+    {
+        if(item->dataIndex().isValidForSeries())
+        {
+            emit exportData(item->dataIndex());
+        }
+
+        else if(item->dataIndex().isValidForStudy())
+        {
+            for (unsigned int i = 0; i<item->childCount(); i++)
+                emit exportData(item->child(i)->dataIndex());
+        }
+
+        if(item->dataIndex().isValidForPatient())
+        {
+            for (unsigned int i = 0; i<item->childCount(); i++)
+            {
+                medAbstractDatabaseItem *study = item->child(i);
+                for (unsigned int j = 0; j<study->childCount(); j++)
+                {
+                    emit exportData(study->child(j)->dataIndex());
+                }
+            }
+        }
+    }
 }
 
 void medDatabaseView::onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)

--- a/src/medCore/gui/toolboxes/medActionsToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medActionsToolBox.cpp
@@ -202,6 +202,19 @@ void medActionsToolBox::patientSelected(const medDataIndex& index)
 }
 
 /**
+* Slot to call when an item representing a study has been selected.
+* The appropriate buttons will appear in the toolbox.
+* @param index – the medDataIndex of the db item
+**/
+void medActionsToolBox::studySelected(const medDataIndex& index)
+{
+    if( !(medDataManager::instance()->controllerForDataSource(index.dataSourceId())->isPersistent()) )
+        updateButtons("Unsaved Study");
+    else
+        updateButtons("Study");
+}
+
+/**
 * Slot to call when an item representing a series has been selected.
 * The appropriate buttons will appear in the toolbox.
 * @param index – the medDataIndex of the db item
@@ -292,6 +305,16 @@ void medActionsToolBox::initializeItemToActionsMap()
     d->itemToActions.insert("Unsaved Patient", "New Patient");
     d->itemToActions.insert("Unsaved Patient", "New Study");
     d->itemToActions.insert("Unsaved Patient", "Edit");
+
+    d->itemToActions.insert("Study", "Remove");
+    d->itemToActions.insert("Study", "Export");
+    d->itemToActions.insert("Study", "New Patient");
+    d->itemToActions.insert("Study", "Edit");
+
+    d->itemToActions.insert("Unsaved Study", "Remove");
+    d->itemToActions.insert("Unsaved Study", "Save");
+    d->itemToActions.insert("Unsaved Study", "New Patient");
+    d->itemToActions.insert("Unsaved Study", "Edit");
 
     d->itemToActions.insert("Series", "View");
     d->itemToActions.insert("Series", "Export");

--- a/src/medCore/gui/toolboxes/medActionsToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medActionsToolBox.cpp
@@ -282,6 +282,7 @@ void medActionsToolBox::initializeItemToActionsMap()
     d->itemToActions = QMultiMap<QString, QString>();
 
     d->itemToActions.insert("Patient", "Remove");
+    d->itemToActions.insert("Patient", "Export");
     d->itemToActions.insert("Patient", "New Patient");
     d->itemToActions.insert("Patient", "New Study");
     d->itemToActions.insert("Patient", "Edit");

--- a/src/medCore/gui/toolboxes/medActionsToolBox.h
+++ b/src/medCore/gui/toolboxes/medActionsToolBox.h
@@ -64,6 +64,7 @@ signals:
 public slots:
 
     void patientSelected(const medDataIndex& index);
+    void studySelected(const medDataIndex& index);
     void seriesSelected(const medDataIndex& index);
     void noPatientOrSeriesSelected();
     void selectedPathsChanged(const QStringList& paths);


### PR DESCRIPTION
For now, you can only export series by series, which, if you want to export a whole patient, can be quite of a pain.
This PR brings the export function to study and patient.

Also medActionTbx (the tbx in the Browser) was not updated when selecting a study, so I added a behaviour.