### PR TITLE
Fixes crash when dropping mesh then image

### DIFF
--- a/src/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -819,7 +819,6 @@ void vtkImageView3D::SetVisibility (int visibility, int layer)
     }
     this->GetImage3DDisplayForLayer(layer)->SetVisibility(visibility);
   }
-  this->InternalUpdate();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
The (MUSIC) [commit that adds it](https://github.com/LoicCadour/medInria-public/commit/afa5f8c87bee063ed6f7e3a5919d59c1957e17d8) aimed at improving VR when some layers were hidden. Can't find the need of this particular line.
