### PR TITLE
[mscPaintAlgo] close & open view, mask disappear

### DIFF
--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -1519,6 +1519,8 @@ void AlgorithmPaintToolBox::addSliceToStack(medAbstractView * view,const unsigne
 
 void AlgorithmPaintToolBox::onViewClosed()
 {
+    clearMask();
+
     medAbstractView *viewClosed = qobject_cast<medAbstractView*>(QObject::sender());
     if (m_undoStacks->value(viewClosed))
     {


### PR DESCRIPTION
From error #2 in https://github.com/Inria-Asclepios/music/issues/168

"If the user closes the view, and re-opens it, the drawing comes back"

:m:
