### PR TITLE
[itkFiltersToolBox] object name for run button

### DIFF
--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -300,6 +300,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medFilteringAbstractT
 
     // Run button:
     QPushButton *runButton = new QPushButton ( tr ( "Run" ) );
+    runButton->setObjectName("Run");
     runButton->setFocusPolicy ( Qt::NoFocus );
     runButton->setToolTip(tr("Launch the selected filter"));
 


### PR DESCRIPTION
Need this too for the pipelines. (By factorising the pipeline code, some crashes have appeared relating to missing object names, which explains these mini-PRs).