### PR TITLE
[mesh] import/export metadata

### DIFF
--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -13,13 +13,17 @@
 
 #include <vtkDataMeshReader.h>
 
-#include <vtkErrorCode.h>
-
-#include <medAbstractData.h>
 #include <medAbstractDataFactory.h>
+#include <medMetaDataKeys.h>
 
+#include <vtkErrorCode.h>
+#include <vtkFieldData.h>
 #include <vtkMetaVolumeMesh.h>
 #include <vtkMetaSurfaceMesh.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataReader.h>
+#include <vtkStringArray.h>
+#include <vtkXMLPolyDataReader.h>
 
 const char vtkDataMeshReader::ID[] = "vtkDataMeshReader";
 
@@ -51,7 +55,6 @@ bool vtkDataMeshReader::canRead(const QStringList& paths){
 bool vtkDataMeshReader::readInformation(const QString& path) {
     medAbstractData *medData = medAbstractDataFactory::instance()->create("vtkDataMesh");
     this->setData(medData);
-    medData->addMetaData("FilePath", QStringList() << path); // useful ?
     
     return true;
 }
@@ -66,8 +69,6 @@ bool vtkDataMeshReader::read(const QString& path) {
     setProgress(0);
     readInformation(path);
     setProgress(50);
-
-    qDebug() << "Can read with: " << identifier();
 
     if (medAbstractData * medData = dynamic_cast<medAbstractData*>(data()))
     {
@@ -89,26 +90,110 @@ bool vtkDataMeshReader::read(const QString& path) {
             return false;
         }
 
-        try
+        // Get the extension of the filename
+        QFileInfo pathfile(path);
+        QString extension = pathfile.completeSuffix();
+
+        if (extension.compare("vtk") == 0) // VTK files
+        {
+            // Extract data and header from the file
+            QString header;
+            vtkSmartPointer<vtkPolyDataReader> reader = vtkPolyDataReader::New();
+            reader->SetFileName(path.toUtf8().constData());
+            try
+            {
+                reader->SetFileName(path.toLocal8Bit().constData());
+                reader->Update();
+
+                header = reader->GetHeader();
+                dataSet->Read(path.toLocal8Bit().constData());
+            }
+            catch (vtkErrorCode::ErrorIds error)
+            {
+                qDebug() << "vtkDataMeshReader: " << vtkErrorCode::GetStringFromErrorCode(error);
+                return false;
+            }
+
+            medData->setData(dataSet);
+
+            // Parse header and save metadata in medData
+            parseHeaderVtk(header, medData);
+        }
+        else // VTP files
         {
             dataSet->Read(path.toLocal8Bit().constData());
-        } catch (...)
-        {
-            qDebug() << "Loading the vtkDataMesh failed, error while parsing !";
-            return false;
+            medData->setData(dataSet);
+
+            // Extract field data from the xml file
+            vtkSmartPointer<vtkXMLPolyDataReader> reader = vtkSmartPointer<vtkXMLPolyDataReader>::New();
+            reader->SetFileName(path.toLocal8Bit().constData());
+            reader->Update();
+
+            if (reader->GetOutput()->GetFieldData())
+            {
+                parseHeaderVtp(reader->GetOutput()->GetFieldData(), medData);
+            }
         }
-
-        medData->setData(dataSet);
-        std::string patientName, patientID;
-
-        if (dataSet->GetMetaData("PatientName", patientName))
-            medData->setMetaData("PatientName", QString::fromStdString(patientName));
-        if (dataSet->GetMetaData("PatientID", patientID))
-            medData->setMetaData("PatientID", QString::fromStdString(patientID));
     }
 
     setProgress(100);
     return true;
+}
+
+QStringList vtkDataMeshReader::metaDataKeysToCopy()
+{
+    QStringList keys;
+
+    keys << medMetaDataKeys::PatientID.key()
+         << medMetaDataKeys::PatientName.key()
+         << medMetaDataKeys::Age.key()
+         << medMetaDataKeys::BirthDate.key()
+         << medMetaDataKeys::Gender.key()
+         << medMetaDataKeys::Description.key()
+         << medMetaDataKeys::StudyID.key()
+         << medMetaDataKeys::StudyDicomID.key()
+         << medMetaDataKeys::StudyDescription.key()
+         << medMetaDataKeys::Institution.key()
+         << medMetaDataKeys::Referee.key()
+         << medMetaDataKeys::StudyDate.key()
+         << medMetaDataKeys::StudyTime.key()
+         << medMetaDataKeys::Performer.key()
+         << medMetaDataKeys::Report.key()
+         << medMetaDataKeys::Protocol.key()
+         << medMetaDataKeys::Origin.key()
+         << medMetaDataKeys::AcquisitionDate.key()
+         << medMetaDataKeys::AcquisitionTime.key()
+         << medMetaDataKeys::Modality.key()
+         << medMetaDataKeys::Orientation.key();
+
+    return keys;
+}
+
+void vtkDataMeshReader::parseHeaderVtk(QString header, medAbstractData* medData)
+{
+    QStringList list = header.split("\t");
+
+    QStringList keyList = metaDataKeysToCopy();
+    foreach(QString key, keyList)
+    {
+        if (list.contains(key))
+        {
+            medData->setMetaData(key, list.at(list.indexOf(key)+1));
+        }
+    }
+}
+
+void vtkDataMeshReader::parseHeaderVtp(vtkSmartPointer<vtkFieldData> field, medAbstractData* medData)
+{
+    QStringList keyList = metaDataKeysToCopy();
+    foreach(QString key, keyList)
+    {
+        if (field->HasArray(key.toStdString().c_str()))
+        {
+            vtkAbstractArray* subArr = field->GetAbstractArray(key.toStdString().c_str());
+            medData->setMetaData(key, QString(subArr->GetVariantValue(0).ToString()));
+        }
+    }
 }
 
 bool vtkDataMeshReader::read(const QStringList& paths) {

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -190,7 +190,6 @@ void vtkDataMeshReader::parseHeaderVtk(QString header, medAbstractData* medData)
 
         if (cartoList.count() == 4)
         {
-            std::cout<<"vtkDataMeshReader::parseHeaderVtk CARTO OK"<<std::endl;
             medData->setMetaData(medMetaDataKeys::PatientName.key(), cartoList.at(1)+QString("^")+cartoList.at(2));
             medData->setMetaData(medMetaDataKeys::PatientID.key(),   cartoList.at(3));
         }

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -173,12 +173,26 @@ void vtkDataMeshReader::parseHeaderVtk(QString header, medAbstractData* medData)
 {
     QStringList list = header.split("\t");
 
-    QStringList keyList = metaDataKeysToCopy();
-    foreach(QString key, keyList)
+    if (list.count() > 1) // Regular VTK from MUSIC
     {
-        if (list.contains(key))
+        QStringList keyList = metaDataKeysToCopy();
+        foreach(QString key, keyList)
         {
-            medData->setMetaData(key, list.at(list.indexOf(key)+1));
+            if (list.contains(key))
+            {
+                medData->setMetaData(key, list.at(list.indexOf(key)+1));
+            }
+        }
+    }
+    else // Carto VTK
+    {
+        QStringList cartoList = header.split(" ");
+
+        if (cartoList.count() == 4)
+        {
+            std::cout<<"vtkDataMeshReader::parseHeaderVtk CARTO OK"<<std::endl;
+            medData->setMetaData(medMetaDataKeys::PatientName.key(), cartoList.at(1)+QString("^")+cartoList.at(2));
+            medData->setMetaData(medMetaDataKeys::PatientID.key(),   cartoList.at(3));
         }
     }
 }

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -94,7 +94,7 @@ bool vtkDataMeshReader::read(const QString& path) {
         QFileInfo pathfile(path);
         QString extension = pathfile.completeSuffix();
 
-        if (extension.compare("vtk") == 0) // VTK files
+        if (extension == "vtk") // VTK files
         {
             // Extract data and header from the file
             QString header;
@@ -118,7 +118,7 @@ bool vtkDataMeshReader::read(const QString& path) {
             // Parse header and save metadata in medData
             parseHeaderVtk(header, medData);
         }
-        else // VTP files
+        else if (extension == "vtp") // VTP files
         {
             dataSet->Read(path.toLocal8Bit().constData());
             medData->setData(dataSet);
@@ -132,6 +132,21 @@ bool vtkDataMeshReader::read(const QString& path) {
             {
                 parseHeaderVtp(reader->GetOutput()->GetFieldData(), medData);
             }
+        }
+        else if ((extension == "mesh") || (extension == "obj")) // MESH or OBJ files
+        {
+            try
+            {
+                dataSet->Read(path.toLocal8Bit().constData());
+            } catch (...)
+            {
+                qDebug() << "vtkDataMeshReader::read -> loading the vtkDataMesh failed, error while parsing !";
+                return false;
+            }
+        }
+        else
+        {
+            return false;
         }
     }
 

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -99,7 +99,6 @@ bool vtkDataMeshReader::read(const QString& path) {
             // Extract data and header from the file
             QString header;
             vtkSmartPointer<vtkPolyDataReader> reader = vtkPolyDataReader::New();
-            reader->SetFileName(path.toUtf8().constData());
             try
             {
                 reader->SetFileName(path.toLocal8Bit().constData());

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -140,7 +140,7 @@ bool vtkDataMeshReader::read(const QString& path) {
                 dataSet->Read(path.toLocal8Bit().constData());
             } catch (...)
             {
-                qDebug() << "vtkDataMeshReader::read -> loading the vtkDataMesh failed, error while parsing !";
+                qDebug() << "vtkDataMeshReader::read -> loading the vtkDataMesh failed";
                 return false;
             }
         }

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.h
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.h
@@ -14,7 +14,10 @@
 #pragma once
 
 #include <dtkCore/dtkAbstractDataReader.h>
+#include <medAbstractData.h>
 #include <vtkDataMeshPluginExport.h>
+#include <vtkFieldData.h>
+#include <vtkSmartPointer.h>
 
 class vtkDataSetReader;
 
@@ -50,6 +53,9 @@ public slots:
 private:
 
     static const char ID[];
+    QStringList metaDataKeysToCopy();
+    void parseHeaderVtk(QString header, medAbstractData* medData);
+    void parseHeaderVtp(vtkSmartPointer<vtkFieldData> field, medAbstractData *medData);
 };
 
 

--- a/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.cpp
+++ b/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.cpp
@@ -74,7 +74,7 @@ bool vtkDataMeshWriter::write(const QString& path)
   QFileInfo pathfile(path);
   QString extension = pathfile.completeSuffix();
 
-  if (extension.compare("vtk") == 0) // VTK files
+  if (extension == "vtk") // VTK files
   {
       QString header = getHeaderVtk();
 
@@ -92,7 +92,7 @@ bool vtkDataMeshWriter::write(const QString& path)
           return false;
       }
   }
-  else // VTP files
+  else if (extension == "vtp") // VTP files
   {
       addHeaderVtpToMesh(mesh);
 
@@ -104,6 +104,21 @@ bool vtkDataMeshWriter::write(const QString& path)
         writer->SetInputData(mesh->GetDataSet());
       #endif
         writer->Write();
+  }
+  else if ((extension == "mesh") || (extension == "obj")) // MESH or OBJ files
+  {
+      try
+      {
+          mesh->Write(path.toLocal8Bit().constData());
+      } catch (...)
+      {
+          qDebug() << "vtkDataMeshWriter::write -> writing the vtkDataMesh failed.";
+          return false;
+      }
+  }
+  else
+  {
+      return false;
   }
 
   return true;

--- a/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.cpp
+++ b/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.cpp
@@ -13,12 +13,18 @@
 
 #include <vtkDataMeshWriter.h>
 
-#include <medAbstractDataFactory.h>
-#include <medAbstractData.h>
 #include <dtkLog/dtkLog.h>
 
-#include <vtkMetaDataSet.h>
+#include <medAbstractDataFactory.h>
+#include <medAbstractData.h>
+#include <medMetaDataKeys.h>
 
+#include <vtkErrorCode.h>
+#include <vtkFieldData.h>
+#include <vtkPolyDataWriter.h>
+#include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
+#include <vtkXMLPolyDataWriter.h>
 
 const char vtkDataMeshWriter::ID[] = "vtkDataMeshWriter";
 
@@ -53,8 +59,6 @@ bool vtkDataMeshWriter::write(const QString& path)
   if (!this->data())
     return false;
 
-  qDebug() << "Can write with: " << this->identifier();
-
   medAbstractData * medData = dynamic_cast<medAbstractData*>(this->data());
 
   if(medData->identifier() != "vtkDataMesh")
@@ -66,11 +70,104 @@ bool vtkDataMeshWriter::write(const QString& path)
   if (!mesh)
     return false;
 
-  mesh->Write(path.toLocal8Bit().constData());
+  // Get the extension of the filename
+  QFileInfo pathfile(path);
+  QString extension = pathfile.completeSuffix();
+
+  if (extension.compare("vtk") == 0) // VTK files
+  {
+      QString header = getHeaderVtk();
+
+      vtkSmartPointer<vtkPolyDataWriter> writer = vtkPolyDataWriter::New();
+      writer->SetFileName(path.toUtf8().constData());
+      try
+      {
+          writer->SetInput(mesh->GetDataSet());
+          writer->SetHeader(header.toAscii().constData());
+          writer->Write();
+      }
+      catch (vtkErrorCode::ErrorIds error)
+      {
+          qDebug() << "vtkDataMeshWriter: " << vtkErrorCode::GetStringFromErrorCode(error);
+          return false;
+      }
+  }
+  else // VTP files
+  {
+      addHeaderVtpToMesh(mesh);
+
+      vtkSmartPointer<vtkXMLPolyDataWriter> writer = vtkSmartPointer<vtkXMLPolyDataWriter>::New();
+        writer->SetFileName(path.toUtf8().constData());
+      #if VTK_MAJOR_VERSION <= 5
+        writer->SetInput(mesh->GetDataSet());
+      #else
+        writer->SetInputData(mesh->GetDataSet());
+      #endif
+        writer->Write();
+  }
 
   return true;
 }
 
+QStringList vtkDataMeshWriter::metaDataKeysToCopy()
+{
+    QStringList keys;
+
+    keys << medMetaDataKeys::PatientID.key()
+         << medMetaDataKeys::PatientName.key()
+         << medMetaDataKeys::Age.key()
+         << medMetaDataKeys::BirthDate.key()
+         << medMetaDataKeys::Gender.key()
+         << medMetaDataKeys::Description.key()
+         << medMetaDataKeys::StudyID.key()
+         << medMetaDataKeys::StudyDicomID.key()
+         << medMetaDataKeys::StudyDescription.key()
+         << medMetaDataKeys::Institution.key()
+         << medMetaDataKeys::Referee.key()
+         << medMetaDataKeys::StudyDate.key()
+         << medMetaDataKeys::StudyTime.key()
+         << medMetaDataKeys::Performer.key()
+         << medMetaDataKeys::Report.key()
+         << medMetaDataKeys::Protocol.key()
+         << medMetaDataKeys::Origin.key()
+         << medMetaDataKeys::AcquisitionDate.key()
+         << medMetaDataKeys::AcquisitionTime.key()
+         << medMetaDataKeys::Modality.key()
+         << medMetaDataKeys::Orientation.key();
+
+    return keys;
+}
+
+QString vtkDataMeshWriter::getHeaderVtk()
+{
+    // Create a header line with metadata
+    QStringList keyList = metaDataKeysToCopy();
+
+    QString header = QString("");
+    foreach(QString key, keyList)
+    {
+        if (data()->metadata(key).toStdString().compare("") != 0)
+        {
+            header += key + QString("\t") + data()->metadata(key) + QString("\t");
+        }
+    }
+    return header;
+}
+
+void vtkDataMeshWriter::addHeaderVtpToMesh(vtkMetaDataSet* mesh)
+{
+    // Add FieldData tag to the xml file
+    QStringList keyList = metaDataKeysToCopy();
+
+    foreach(QString key, keyList)
+    {
+        vtkSmartPointer<vtkStringArray> appendData = vtkSmartPointer<vtkStringArray>::New();
+        appendData->SetName(key.toStdString().c_str());
+        appendData->InsertNextValue(data()->metadata(key).toStdString().c_str());
+
+        mesh->GetDataSet()->GetFieldData()->AddArray(appendData);
+    }
+}
 QString vtkDataMeshWriter::description() const
 {
     return tr( "VTK Mesh Writer" );

--- a/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
+++ b/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
@@ -16,6 +16,8 @@
 #include <dtkCore/dtkAbstractDataWriter.h>
 
 #include <vtkDataMeshPluginExport.h>
+#include <vtkMetaDataSet.h>
+
 class vtkDataSetWriter;
 
 class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshWriter : public dtkAbstractDataWriter
@@ -43,6 +45,9 @@ public slots:
 
 private:
     static const char ID[];
+    QStringList metaDataKeysToCopy();
+    QString getHeaderVtk();
+    void addHeaderVtpToMesh(vtkMetaDataSet *mesh);
 };
 
 


### PR DESCRIPTION
This PR adds the export/import of metadata concerning vtk and vtp files.

Vtp files are XML files, and i used vtkFieldData to store metaData. 
In Vtk files, i fill the information string line of the header and parse it in the reader.
I needed also to use specific xml or polydata file readers to catch these metadata.

I tested the output files also in Paraview, no problem.

:m:
