### PR TITLE
[medUtilities] seriesDicomId

### DIFF
--- a/src/medUtilities/medUtilities.cpp
+++ b/src/medUtilities/medUtilities.cpp
@@ -105,6 +105,9 @@ void medUtilities::generateSeriesAndSOPInstanceId(medAbstractData* data)
 
     QString generatedSOPInstanceID = QUuid::createUuid().toString().replace("{", "").replace("}", "");
     data->setMetaData(medMetaDataKeys::SOPInstanceUID.key(), generatedSOPInstanceID);
+    
+    QString generatedSeriesDicomID = QUuid::createUuid().toString().replace("{", "").replace("}", "");
+    data->setMetaData(medMetaDataKeys::SeriesDicomID.key(), generatedSeriesDicomID);
 }
 
 void medUtilities::querySeriesDescription(medAbstractData* data)


### PR DESCRIPTION
I got the duplication/overwriting bug we had a while back while importing data. The function ```generateSeriesAndSOPInstanceId``` fixed this before, but I got the bug on the output of registration. I corrected this by generating a new series DICOM ID in addition to the series ID that is already generated.