### PR TITLE
[reformatWorkspace] automatic creation of tlbx

### DIFF
--- a/src-plugins/reformat/medCropToolBox.h
+++ b/src-plugins/reformat/medCropToolBox.h
@@ -9,7 +9,7 @@ class medCropToolBoxPrivate;
 class REFORMATPLUGIN_EXPORT medCropToolBox : public medSegmentationAbstractToolBox
 {
     Q_OBJECT
-    MED_TOOLBOX_INTERFACE("medCropToolBox", "Image cropping",<<"reformat")
+    MED_TOOLBOX_INTERFACE("medCropToolBox", "Image cropping",<<"view")
 
 public:
     static bool registered();

--- a/src-plugins/reformat/reformatToolBox.h
+++ b/src-plugins/reformat/reformatToolBox.h
@@ -8,9 +8,8 @@ class reformatToolBoxPrivate;
 
 class REFORMATPLUGIN_EXPORT reformatToolBox : public medSegmentationAbstractToolBox
 {
-    Q_OBJECT;
-
-    MED_TOOLBOX_INTERFACE("reformatToolBox","used to reformat an image", << "reformat");
+    Q_OBJECT
+    MED_TOOLBOX_INTERFACE("reformatToolBox","used to reformat an image", << "view")
         
 public:
     reformatToolBox(QWidget *parentToolBox = 0);

--- a/src-plugins/reformat/reformatWorkspace.cpp
+++ b/src-plugins/reformat/reformatWorkspace.cpp
@@ -56,25 +56,10 @@ reformatWorkspace::reformatWorkspace(QWidget *parent) : medAbstractWorkspace(par
         {
             medToolBox* toolBox = medToolBoxFactory::instance()->createToolBox(toolbox, parent);
             addToolBox(toolBox);
+            toolBox->setWorkspace(this);
             toolBox->switchMinimize();
         }
     }
-
-    reformatToolBox * reformatTb = new reformatToolBox();
-    reformatTb->setWorkspace(this);
-    addToolBox(reformatTb);
-    reformatTb->switchMinimize();
-
-    medSegmentationAbstractToolBox * cropTb =
-            qobject_cast<medSegmentationAbstractToolBox*>(medToolBoxFactory::instance()->createToolBox("medCropToolBox"));
-    cropTb->setWorkspace(this);
-    addToolBox(cropTb);
-    cropTb->switchMinimize();
-    
-    superResolutionToolBox * superResolutionTb = new superResolutionToolBox();
-    superResolutionTb->setWorkspace(this);
-    addToolBox(superResolutionTb);
-    superResolutionTb->switchMinimize();
 }
 
 reformatWorkspace::~reformatWorkspace()

--- a/src-plugins/reformat/superResolutionToolBox.h
+++ b/src-plugins/reformat/superResolutionToolBox.h
@@ -24,8 +24,9 @@ class superResolutionToolBoxPrivate;
 
 class REFORMATPLUGIN_EXPORT superResolutionToolBox : public medSegmentationAbstractToolBox
 {
-    Q_OBJECT;
-    MED_TOOLBOX_INTERFACE("superResolutionToolBox","shape based interpolation algorithm", << "reformat");
+    Q_OBJECT
+    MED_TOOLBOX_INTERFACE("superResolutionToolBox",
+                          "shape based interpolation algorithm", << "view")
 
 public:
     superResolutionToolBox(QWidget *parentToolBox = 0);


### PR DESCRIPTION
I did a new toolbox for the reformat workspace, however, it's not in the reformat plugin so i searched the identifier for reformat toolboxes. It appears that the identifier is "view" (it's not very intuitive) and that we can make it full automatic.

I needed also to add toolBox->setWorkspace(this); for my new toolbox.

:m:
