### PR TITLE
[URGENT] Solves db creation problem on Linux and Mac 

### DIFF
--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -168,12 +168,6 @@ const QSqlDatabase& medDatabaseController::database(void) const
 
 bool medDatabaseController::createConnection(void)
 {
-//    if(!QDir(medStorage::dataLocation()).exists())
-//    {
-//        qDebug()<<"Database path does not exist: "<<medStorage::dataLocation();
-//        return false;
-//    }
-
     medStorage::mkpath(medStorage::dataLocation() + "/");
 
     if (this->m_database.databaseName().isEmpty())

--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -168,11 +168,11 @@ const QSqlDatabase& medDatabaseController::database(void) const
 
 bool medDatabaseController::createConnection(void)
 {
-    if(!QDir(medStorage::dataLocation()).exists())
-    {
-        qDebug()<<"Database path does not exist: "<<medStorage::dataLocation();
-        return false;
-    }
+//    if(!QDir(medStorage::dataLocation()).exists())
+//    {
+//        qDebug()<<"Database path does not exist: "<<medStorage::dataLocation();
+//        return false;
+//    }
 
     medStorage::mkpath(medStorage::dataLocation() + "/");
 


### PR DESCRIPTION
Pb is due ti the fact that the path of the db doesn't exist, i.e *.../local/INRIA_IHU-LIRYC/MUSIC/* has not been created.

The code I am removing was originally written to manage the rare case where your db path points on an external hard disk, and for some reason you start MUSIC without the external HD. It was preventing to create a new path (= creating new folders) like : /Volume/externalHD/MUSIC ... and create a new db there.
In the end it's not a big deal, since the user can easily notice that MUSIC is not pointing at the right db and since he was able at first hand to change his db path, he could do it again.

