### PR TITLE
[doc] MUSIC help link on homepage

### DIFF
--- a/app/medInria/medHomepageArea.cpp
+++ b/app/medInria/medHomepageArea.cpp
@@ -489,7 +489,7 @@ void medHomepageArea::onShowInfo()
 
 void medHomepageArea::onShowHelp()
 {
-    QDesktopServices::openUrl(QUrl("http://med.inria.fr/help/documentation"));
+    QDesktopServices::openUrl(QUrl("https://www-sop.inria.fr/asclepios/software/MUSIC/MUSIC_User_Manual.pdf"));
 }
 
 void medHomepageArea::onShowSettings()


### PR DESCRIPTION
Change the link to the documentation on the homepage to the User Manual on https://www-sop.inria.fr/asclepios/software/MUSIC/MUSIC_User_Manual.pdf

We can extract a html file from github wikis, so it's possible maybe to switch from the pdf to the html file in the future.
